### PR TITLE
Feat/multiple roots series movies

### DIFF
--- a/movies.go
+++ b/movies.go
@@ -10,8 +10,8 @@ type Movies struct {
 	movie_set  []string
 }
 
-func (movie *Movies) split_movies_by_type(movie_entries []string) error {
-	for _, movie_entry := range movie_entries {
+func (movie *Movies) split_movies_by_type(movie_entries MovieEntries) error {
+	for movie_entry := range movie_entries {
 		files, err := os.ReadDir(movie_entry)
 		if err != nil {
 			return err

--- a/parse_args.go
+++ b/parse_args.go
@@ -23,6 +23,29 @@ type Args struct {
 	naming_scheme   Arg
 }
 
+func (a Args) get_roots() []string {
+	var roots []string
+	for _, arg := range a.root {
+		roots = append(roots, arg.value)
+	}
+	return roots
+}
+func (a Args) get_series() []string {
+	var series []string
+	for _, arg := range a.series {
+		series = append(series, arg.value)
+	}
+	return series
+}
+func (a Args) get_movies() []string {
+	var movies []string
+	for _, arg := range a.movies {
+		movies = append(movies, arg.value)
+	}
+	return movies
+}
+
+
 func parse_args(args []string) (Args, error) {
 	if len(args) < 1 {
 		return Args{}, fmt.Errorf("not enough arguments")

--- a/parse_args.go
+++ b/parse_args.go
@@ -23,21 +23,24 @@ type Args struct {
 	naming_scheme   Arg
 }
 
-func (a Args) get_roots() []string {
+// returns root directories as a slice of strings
+func (a Args) Roots() []string {
 	var roots []string
 	for _, arg := range a.root {
 		roots = append(roots, arg.value)
 	}
 	return roots
 }
-func (a Args) get_series() []string {
+// returns series directories as a slice of strings
+func (a Args) Series() []string {
 	var series []string
 	for _, arg := range a.series {
 		series = append(series, arg.value)
 	}
 	return series
 }
-func (a Args) get_movies() []string {
+// returns movies directories as a slice of strings
+func (a Args) Movies() []string {
 	var movies []string
 	for _, arg := range a.movies {
 		movies = append(movies, arg.value)

--- a/series.go
+++ b/series.go
@@ -14,8 +14,8 @@ type Series struct {
 	multiple_season_with_movies []string
 }
 
-func (series *Series) split_series_by_type(series_entries []string) error {
-	for _, series_entry := range series_entries {
+func (series *Series) split_series_by_type(series_entries SeriesEntries) error {
+	for series_entry := range series_entries {
 		files, err := os.ReadDir(series_entry)
 		if err != nil {
 			return err


### PR DESCRIPTION
### new
1. getters for roots, series, and movies
  - `Args` properties `Args.root`, `Args.series`, and `Args.movies` all return `[]Arg` so the new methods `Args.Root()`, `Args.Series()`, and `Args.Movies()` all return the expected `[]string` counterpart

### changes
1. old `get_root_dirs` which separates series and movie root dirs from the passed root, and gets entries for both is now divided into 3 functions
    1. `separate_roots` now handles the separating series and movie root dirs from passed root
    2. `fetch_subdirs` now handles the getting of entries from passed dir (can be used for both series and movie root dirs)
    3. `fetch_entries` now congregates all series and movie entries based on user input in cli 
        - since user can input multiple root dirs and/or series dirs and/or movie dirs, this handles the logic differently for each type
        - it uses the previous two functions here to do this by separating roots first then fetching the subdirs (aka entries)