### PR TITLE
Chore/refactor rename prereqs

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,21 +22,18 @@ func main() {
 	if len(args.movies) > 0 {
 		fmt.Println("movies: ", args.movies[0])
 	}
-	ken, err := args.keep_ep_nums.find().get()
-	if err != nil {
-		panic(err)
-	} 
-	fmt.Println("keep episode numbers: ", ken)
-	sen, err := args.starting_ep_num.find().get()
-	if err != nil {
-		panic(err)
+	ken, err := args.keep_ep_nums.get()
+	if err == nil {
+		fmt.Println("keep episode numbers: ", ken)
 	}
-	fmt.Println("starting episode number: ", sen)
-	ns, err := args.naming_scheme.find().get()
-	if err != nil {
-		panic(err)
+	sen, err := args.starting_ep_num.get()
+	if err == nil {
+		fmt.Println("starting episode number: ", sen)
 	}
-	fmt.Println("naming scheme: ", ns)
+	ns, err := args.naming_scheme.get()
+	if err == nil {
+		fmt.Println("naming scheme: ", ns)
+	}
 
 	series_entries, movie_entries, err := fetch_entries(args.root, args.series, args.movies)
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -14,19 +14,31 @@ func main() {
 	}
 
 	if len(args.root) > 0 {
-		fmt.Println("root: ", args.root[0].value)
+		fmt.Println("root: ", args.root[0])
 	}
 	if len(args.series) > 0 {
-		fmt.Println("series: ", args.series[0].value)
+		fmt.Println("series: ", args.series[0])
 	}
 	if len(args.movies) > 0 {
-		fmt.Println("movies: ", args.movies[0].value)
+		fmt.Println("movies: ", args.movies[0])
 	}
-	fmt.Println("keep episode numbers: ", args.keep_ep_nums.value)
-	fmt.Println("starting episode number: ", args.starting_ep_num.value)
-	fmt.Println("naming scheme: ", args.naming_scheme.value)
+	ken, err := args.keep_ep_nums.find().get()
+	if err != nil {
+		panic(err)
+	} 
+	fmt.Println("keep episode numbers: ", ken)
+	sen, err := args.starting_ep_num.find().get()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("starting episode number: ", sen)
+	ns, err := args.naming_scheme.find().get()
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println("naming scheme: ", ns)
 
-	series_entries, movie_entries, err := fetch_entries(args.Roots(), args.Series(), args.Movies())
+	series_entries, movie_entries, err := fetch_entries(args.root, args.series, args.movies)
 	if err != nil {
 		panic(err)
 	}

--- a/main.go
+++ b/main.go
@@ -99,7 +99,7 @@ func main() {
 
 	fmt.Println("test for named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", false, 1, false)
+		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false))
 		if err != nil {
 			panic(err)
 		}
@@ -114,7 +114,7 @@ func main() {
 
 	fmt.Println("test for single season no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", false, 1, true)
+		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true))
 		if err != nil {
 			panic(err)
 		}
@@ -129,7 +129,7 @@ func main() {
 
 	fmt.Println("test for single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", true, 1, false)
+		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false))
 		if err != nil {
 			panic(err)
 		}
@@ -144,7 +144,7 @@ func main() {
 
 	fmt.Println("test for multiple season no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", false, 1, false)
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false))
 		if err != nil {
 			panic(err)
 		}
@@ -159,7 +159,7 @@ func main() {
 
 	fmt.Println("test for multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", false, 1, false)
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false))
 		if err != nil {
 			panic(err)
 		}

--- a/option_type.go
+++ b/option_type.go
@@ -1,0 +1,65 @@
+package main
+
+import "errors"
+
+type OptionalData[T any] interface {
+	get() (T, error)
+}
+type None[T any] struct{}
+type Some[T any] struct {data T}
+
+func (None[T]) get() (T, error) {
+	var data T
+	return data, errors.New("no data, is none")
+}
+
+func (s Some[T]) get() (T, error) {
+	return s.data, nil
+}
+
+func create_some[T any](data T) OptionalData[T] {
+	return Some[T]{data}
+}
+
+func create_none[T any]() OptionalData[T] {
+	return None[T]{}
+}
+
+
+type Option[T any] interface {
+	is_none() bool
+	is_some() bool
+	find() OptionalData[T]
+}
+
+func none[T any]() Option[T] {
+	return None[T]{}
+}
+
+func (None[T]) is_none() bool {
+	return true
+}
+
+func (None[T]) is_some() bool {
+	return false
+}
+
+func (None[T]) find() OptionalData[T] {
+	return create_none[T]()
+}
+
+func some[T any](data T) Option[T] {
+	return Some[T]{data}
+}
+
+func (Some[T]) is_none() bool {
+	return false
+}
+
+func (Some[T]) is_some() bool {
+	return true
+}
+
+func (s Some[T]) find() OptionalData[T] {
+	return create_some[T](s.data)
+}

--- a/option_type.go
+++ b/option_type.go
@@ -2,34 +2,13 @@ package main
 
 import "errors"
 
-type OptionalData[T any] interface {
-	get() (T, error)
-}
 type None[T any] struct{}
 type Some[T any] struct {data T}
-
-func (None[T]) get() (T, error) {
-	var data T
-	return data, errors.New("no data, is none")
-}
-
-func (s Some[T]) get() (T, error) {
-	return s.data, nil
-}
-
-func create_some[T any](data T) OptionalData[T] {
-	return Some[T]{data}
-}
-
-func create_none[T any]() OptionalData[T] {
-	return None[T]{}
-}
-
 
 type Option[T any] interface {
 	is_none() bool
 	is_some() bool
-	find() OptionalData[T]
+	get() (T, error)
 }
 
 func none[T any]() Option[T] {
@@ -44,8 +23,9 @@ func (None[T]) is_some() bool {
 	return false
 }
 
-func (None[T]) find() OptionalData[T] {
-	return create_none[T]()
+func (None[T]) get() (T, error) {
+	var data T
+	return data, errors.New("no data, is none")
 }
 
 func some[T any](data T) Option[T] {
@@ -60,6 +40,6 @@ func (Some[T]) is_some() bool {
 	return true
 }
 
-func (s Some[T]) find() OptionalData[T] {
-	return create_some[T](s.data)
+func (s Some[T]) get() (T, error) {
+	return s.data, nil
 }

--- a/rename.go
+++ b/rename.go
@@ -75,7 +75,7 @@ func (info *SeriesInfo) rename() error {
 		}
 		
 		var ep_num int
-		sen, err := info.starting_ep_num.find().get()
+		sen, err := info.starting_ep_num.get()
 		if err != nil {
 			return err
 		}
@@ -87,7 +87,7 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		ep_nums := make([]int, 0)
-		ken, err := info.keep_ep_nums.find().get()
+		ken, err := info.keep_ep_nums.get()
 		if err != nil {
 			return err
 		}

--- a/rename.go
+++ b/rename.go
@@ -15,12 +15,12 @@ type Rename interface {
 type SeriesInfo struct {
 	path            string
 	series_type     string
-	keep_ep_nums    bool
-	starting_ep_num int
 	seasons         map[int]string
 	movies          []string
-	has_season_0    bool
 	extras_dirs     []string
+	keep_ep_nums    Option[bool]
+	starting_ep_num Option[int]
+	has_season_0    Option[bool]
 }
 
 type MovieInfo struct {
@@ -75,14 +75,24 @@ func (info *SeriesInfo) rename() error {
 		}
 		
 		var ep_num int
-		if info.starting_ep_num > 0 {
-			ep_num = info.starting_ep_num
+		sen, err := info.starting_ep_num.find().get()
+		if err != nil {
+			return err
+		}
+
+		if sen > 0 {
+			ep_num = sen
 		} else {
 			ep_num = 1
 		}
 
 		ep_nums := make([]int, 0)
-		if info.keep_ep_nums {
+		ken, err := info.keep_ep_nums.find().get()
+		if err != nil {
+			return err
+		}
+
+		if ken {
 			for _, file := range media_files {
 				ep_num, err = read_episode_num(file)
 				if err != nil {

--- a/rename.go
+++ b/rename.go
@@ -17,17 +17,14 @@ type SeriesInfo struct {
 	series_type     string
 	seasons         map[int]string
 	movies          []string
-	extras_dirs     []string
 	keep_ep_nums    Option[bool]
 	starting_ep_num Option[int]
-	has_season_0    Option[bool]
 }
 
 type MovieInfo struct {
 	path        string
 	movie_type  string
 	movies      map[string]string
-	extras_dirs []string
 }
 
 func (info *SeriesInfo) rename() error {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -8,17 +8,17 @@ import (
 	"strconv"
 )
 
-func series_rename_prereqs(path string, s_type string, keep_ep_nums bool, starting_ep_num int, has_season_0 bool) (SeriesInfo, error) {
+func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool]) (SeriesInfo, error) {
 	// get prerequsite info for renaming series
 	info := SeriesInfo{
 		path: 				path,
 		series_type: 		s_type,
-		keep_ep_nums: 		keep_ep_nums,
-		starting_ep_num: 	starting_ep_num,
 		seasons: 			make(map[int]string),
 		movies: 			make([]string, 0),
-		has_season_0: 		has_season_0,
 		extras_dirs: 		make([]string, 0),
+		keep_ep_nums: 		keep_ep_nums,
+		starting_ep_num: 	starting_ep_num,
+		has_season_0: 		has_season_0,
 	}
 
 	is_valid_type := map[string]bool{
@@ -31,8 +31,11 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums bool, starti
 	if !is_valid_type[s_type] {
 		return SeriesInfo{}, fmt.Errorf("unknown series type: %s", s_type)
 	}
-
-	seasons, extras_dirs, movies, err := get_series_content(path, s_type, has_season_0)
+	s0, err := has_season_0.find().get()
+	if err != nil {
+		return SeriesInfo{}, err
+	}
+	seasons, extras_dirs, movies, err := get_series_content(path, s_type, s0)
 	if err != nil {
 		return SeriesInfo{}, err
 	}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -31,7 +31,7 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 	if !is_valid_type[s_type] {
 		return SeriesInfo{}, fmt.Errorf("unknown series type: %s", s_type)
 	}
-	s0, err := has_season_0.find().get()
+	s0, err := has_season_0.get()
 	if err != nil {
 		return SeriesInfo{}, err
 	}


### PR DESCRIPTION
### new
1. Option type !!!
    - thank you [top comment](https://stackoverflow.com/questions/71810399/how-to-implement-a-generic-either-type-in-go) for helping me figure out generics 
    - top comment implemented an Either type, I only needed an option type (aka some and none) so I simplified it
### changes
1. refactor to accommodate Option type
2. `keep_ep_nums` and `has_season_0` are Option[bool] type now instead of just bool.
3. `starting_ep_num` is Option[int] type now instead of just int
    - `keep_ep_nums`, `starting_ep_num`, and `has_season_0` all were strings in `series_rename_prereqs` to be processed later. now its properly Option of their respective types or None
4. removed `extra_dirs` from SeriesInfo and `MovieInfo` since I don't do anything with it anyway
5. removed `has_season_0` from `SeriesInfo` since I don't need it for renaming
    - its still useful in getting series content so it was not removed there