### PR TITLE
fix: add validation of directories from user input, remove set implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+test_files

--- a/main_test.go
+++ b/main_test.go
@@ -174,6 +174,22 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
 	}
+	
+	command = []string{"--root", `C:\Users\Cid\Documents\projects\Go\gorn\test_files`, "-s", `C:\Users\Cid\Documents\Projects\Go\gorn\test_files\Series`, "-m", "./test_files/Movies"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'series directory ./test_files/Series is a subdirectory of root directory ./test_files'")
+	} else {
+		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
+	}
+
+	command = []string{"--root", "./test_files", "-r", "./test_files"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'root directory ./test_files is a duplicate'")
+	} else {
+		t.Log("--root", "./test_files", "-r", "./test_files", "\n\t", err, "\n")
+	}
 
 	t.Log("------------expects success------------")
 
@@ -183,22 +199,6 @@ func Test_parse_args(t *testing.T) {
 		t.Errorf("unexpected error: %s", err)
 	} else {
 		t.Log("--root", "./test_files")
-	}
-
-	command = []string{"--root", "./test_files", "-r", "./test_files"}
-	_, err = parse_args(command)
-	if err != nil {
-		t.Errorf("multiple root directories are allowed: %s", err)
-	} else {
-		t.Log("--root", "./test_files", "-r", "./test_files")
-	}
-
-	command = []string{"--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies"}
-	_, err = parse_args(command)
-	if err != nil {
-		t.Errorf("multiple input directories are allowed: %s", err)
-	} else {
-		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies")
 	}
 
 	command = []string{"--root", "./test_files", "-s0", "all", "yes"}

--- a/media_files.go
+++ b/media_files.go
@@ -7,7 +7,7 @@ import (
 )
 
 type MediaFiles interface {
-	split_by_type(entries Entries) error
+	split_by_type(entries []string) error
 }
 
 type Movies struct {
@@ -22,8 +22,8 @@ type Series struct {
 	multiple_season_with_movies []string
 }
 
-func (movie *Movies) split_by_type(movie_entries Entries) error {
-	for movie_entry := range movie_entries.(MovieEntries) {
+func (movie *Movies) split_by_type(movie_entries []string) error {
+	for _, movie_entry := range movie_entries {
 		files, err := os.ReadDir(movie_entry)
 		if err != nil {
 			return err
@@ -45,8 +45,8 @@ func (movie *Movies) split_by_type(movie_entries Entries) error {
 	return nil
 }
 
-func (series *Series) split_by_type(series_entries Entries) error {
-	for series_entry := range series_entries.(SeriesEntries) {
+func (series *Series) split_by_type(series_entries []string) error {
+	for _, series_entry := range series_entries {
 		files, err := os.ReadDir(series_entry)
 		if err != nil {
 			return err

--- a/parse_args.go
+++ b/parse_args.go
@@ -360,12 +360,14 @@ func validate_roots(root []string, series []string, movies []string) error {
 		}
 	}
 
-	// check if any of the series and movies directories are subdirectories of a root directory
+	// check if any of the series and movies directories are subdirectories of a root directory OR vice versa
 	// and in turn checking if any of the series and movies directories are duplicates of root directories
 	for _, r := range root {
 		for _, s := range series {
 			if strings.EqualFold(filepath.Dir(s), r) {
 				return fmt.Errorf("series directory %s is a subdirectory of root directory %s", s, r)
+			} else if strings.EqualFold(filepath.Dir(r), s) {
+				return fmt.Errorf("root directory %s is a subdirectory of series directory %s", r, s)
 			} else if strings.EqualFold(s, r) {
 				return fmt.Errorf("series directory %s is a duplicate of root directory %s", s, r)
 			}
@@ -373,6 +375,8 @@ func validate_roots(root []string, series []string, movies []string) error {
 		for _, m := range movies {
 			if strings.EqualFold(filepath.Dir(m), r) {
 				return fmt.Errorf("movies directory %s is a subdirectory of root directory %s", m, r)
+			} else if strings.EqualFold(filepath.Dir(r), m) {
+				return fmt.Errorf("root directory %s is a subdirectory of movies directory %s", r, m)
 			} else if strings.EqualFold(m, r) {
 				return fmt.Errorf("movies directory %s is a duplicate of root directory %s", m, r)
 			}
@@ -385,13 +389,12 @@ func validate_roots(root []string, series []string, movies []string) error {
 		for _, m := range movies {
 			if strings.EqualFold(filepath.Dir(m), s) {
 				return fmt.Errorf("series directory %s is a subdirectory of movies directory %s", s, m)
-			} else if strings.EqualFold(s, m) {
-				return fmt.Errorf("series directory %s is a duplicate of movies directory %s", s, m)
 
 			} else if strings.EqualFold(filepath.Dir(s), m) {
 				return fmt.Errorf("movies directory %s is a subdirectory of series directory %s", m, s)
+
 			} else if strings.EqualFold(s, m) {
-				return fmt.Errorf("movies directory %s is a duplicate of series directory %s", m, s)
+				return fmt.Errorf("series directory %s is a duplicate of movies directory %s", s, m)
 			}
 		}
 	}


### PR DESCRIPTION
directories (root, series, dir) are now validated to check if
1. they are subdirectories of each other
2. they are the same directory

and therefore, removing the need for the set implementation since all are forced to be unique during parsing before fetching entries