### PR TITLE
Feat/custom scheme rename

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	fmt.Println("test for named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -120,7 +120,7 @@ func main() {
 
 	fmt.Println("test for single season no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true))
+		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -135,7 +135,7 @@ func main() {
 
 	fmt.Println("test for single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -150,7 +150,7 @@ func main() {
 
 	fmt.Println("test for multiple season no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -165,7 +165,7 @@ func main() {
 
 	fmt.Println("test for multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -438,13 +439,16 @@ func Test_split_regex_by_pipe(t *testing.T) {
 func Test_generate_new_name(t *testing.T) {
 	path := filepath.Clean(`.test_files\Series\Series_seasonal\Season 1\1234567890.mp4`)
 	t.Log("------------expects success------------")
-	name, err := generate_new_name(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,6>`),
+	name, err := generate_new_name(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`),
 									2, 1, 3, 2,
-									"title", ".ext",
-									path)
+									"title", path)
 	if err != nil {
 		t.Error(err)
 	} else {
-		t.Log("\n\told: ", `S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`, "\n\tnew: ", name)
+		if strings.ReplaceAll(name, "S001E02 - Series Season ies 6.mp4", "") != "" {
+			t.Errorf("expected 'S001E02 - Series Season ies 6.mp4' got '%s'", name)
+		} else {
+			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: '.*r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -15,20 +16,20 @@ func Test_parse_args(t *testing.T) {
 		t.Log("--root", "--series", "--movies", "\n\t", err, "\n")
 	}
 
-	command =[]string{"-r", "-s", "-m"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root dir path'")
-	} else {
-		t.Log("-r", "-s", "-m", "\n\t", err, "\n")
-	}
-
 	command =[]string{"-s", "--series", "-r", "--root",  "-m", "--movies"}
 	_, err = parse_args(command)
 	if err == nil {
 		t.Errorf("expected error 'missing series dir path'")
 	} else {
 		t.Log("-s", "--series", "-r", "--root",  "-m", "--movies", "\n\t", err, "\n")
+	}
+
+	command =[]string{"-r", "-s", "-m"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'missing root dir path'")
+	} else {
+		t.Log("-r", "-s", "-m", "\n\t", err, "\n")
 	}
 
 	command =[]string{"-m", "--movies", "-r", "--root",  "-s", "--series"}
@@ -46,14 +47,6 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("--root", "./test_files", "./test_files", "\n\t", err, "\n")
 	}
-	
-	command = []string{"-s", "./test_files", "./test_files"} 
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple values for one flag is not allowed'")
-	} else {
-		t.Log("-s", "./test_files", "./test_files", "\n\t", err, "\n")
-	}
 
 	command = []string{"-m", "./test_files", "./test_files"}
 	_, err = parse_args(command)
@@ -61,6 +54,14 @@ func Test_parse_args(t *testing.T) {
 		t.Errorf("expected error 'multiple values for one flag is not allowed'")
 	} else {
 		t.Log("-m", "./test_files", "./test_files", "\n\t", err, "\n")
+	}
+	
+	command = []string{"-s", "./test_files", "./test_files"} 
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'multiple values for one flag is not allowed'")
+	} else {
+		t.Log("-s", "./test_files", "./test_files", "\n\t", err, "\n")
 	}
 
 	command = []string{"./test_files"}
@@ -71,20 +72,20 @@ func Test_parse_args(t *testing.T) {
 		t.Log("./test_files", "\n\t", err, "\n")
 	}
 
-	command = []string{"-s0", "all", "yes"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root/series/movies dir path'")
-	} else {
-		t.Log("-s0", "all", "yes", "\n\t", err, "\n")
-	}
-
 	command = []string{"-r", "./test_files", "--season-0", "all", "1"}
 	_, err = parse_args(command)
 	if err == nil {
 		t.Errorf("expected error '1 is not a valid arg. must be yes or no'")
 	} else {
 		t.Log("-r", "./test_files", "--season-0", "all", "1", "\n\t", err, "\n")
+	}
+
+	command = []string{"-s0", "all", "yes"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'missing root/series/movies dir path'")
+	} else {
+		t.Log("-s0", "all", "yes", "\n\t", err, "\n")
 	}
 
 	command = []string{"-r", "./test_files", "--season-0", "yes"}
@@ -95,14 +96,6 @@ func Test_parse_args(t *testing.T) {
 		t.Log("-r", "./test_files", "--season-0", "yes", "\n\t", err, "\n")
 	}
 
-	command = []string{"-r", "./test_files", "--season-0", "-s0"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error '-s0 is not a valid arg. must be all or var'")
-	} else {
-		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
-	}
-
 	command = []string{"-ken", "all", "yes"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -110,7 +103,7 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("-ken", "all", "yes", "\n\t", err, "\n")
 	}
-
+	
 	command = []string{"-r", "./test_files", "-ken", "all", "1"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -119,6 +112,14 @@ func Test_parse_args(t *testing.T) {
 		t.Log("-r", "./test_files", "-ken", "all", "1", "\n\t", err, "\n")
 	}
 
+	command = []string{"-r", "./test_files", "--season-0", "-s0"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error '-s0 is not a valid arg. must be all or var'")
+	} else {
+		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
+	}
+	
 	command = []string{"-r", "./test_files", "-ken", "yes"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -166,23 +167,7 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
 	}
-
-	command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple starting-ep-num flags'")
-	} else {
-		t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
-	}
 	
-	command = []string{"--root", `C:\Users\Cid\Documents\projects\Go\gorn\test_files`, "-s", `C:\Users\Cid\Documents\Projects\Go\gorn\test_files\Series`, "-m", "./test_files/Movies"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'series directory ./test_files/Series is a subdirectory of root directory ./test_files'")
-	} else {
-		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
-	}
-
 	command = []string{"--root", "./test_files", "-r", "./test_files"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -190,23 +175,39 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("--root", "./test_files", "-r", "./test_files", "\n\t", err, "\n")
 	}
-
-	t.Log("------------expects success------------")
-
-	command = []string{"--root", "./test_files"}
+	
+	command = []string{"--root", `.\test_files`, "-s", `.\test_files\Series`, "-m", "./test_files/Movies"}
 	_, err = parse_args(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+	if err == nil {
+		t.Errorf("expected error 'series directory ./test_files/Series is a subdirectory of root directory ./test_files'")
 	} else {
-		t.Log("--root", "./test_files")
+		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
 	}
-
+	
+	
+		command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
+		_, err = parse_args(command)
+		if err == nil {
+			t.Errorf("expected error 'multiple starting-ep-num flags'")
+		} else {
+			t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
+		}
+	t.Log("------------expects success------------")
+	
 	command = []string{"--root", "./test_files", "-s0", "all", "yes"}
 	_, err = parse_args(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
 		t.Log("--root", "./test_files", "-s0", "all", "yes")
+	}
+	
+	command = []string{"--root", "./test_files"}
+	_, err = parse_args(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log("--root", "./test_files")
 	}
 
 	command = []string{"--root", "./test_files", "-s0"}
@@ -226,26 +227,19 @@ func Test_naming_scheme_validation(t *testing.T) {
 	} else {
 		t.Log("S<season_num:>E<episode_num:>", "\n\t", err, "\n")
 	}
-
-	err = validate_naming_scheme(`S<season_num: 3`)
-	if err == nil {
-		t.Errorf("expected error 'reached end of string but still in an unclosed api: <season_num: 3'")
-	} else {
-		t.Log(`S<season_num: 3`, "\n\t", err, "\n")
-	}
-
+	
 	err = validate_naming_scheme(`S<season_num: 3l>`)
 	if err == nil {
 		t.Errorf("expected error '3l is not a valid arg. must be a valid positive integer'")
 	} else {
 		t.Log(`S<season_num: 3l>`, "\n\t", err, "\n")
 	}
-
-	err = validate_naming_scheme(`E<episode_num: -2>`)
+		
+	err = validate_naming_scheme(`S<season_num: 3`)
 	if err == nil {
-		t.Errorf("expected error '-2 is not a valid arg. must be a valid positive integer'")
+		t.Errorf("expected error 'reached end of string but still in an unclosed api: <season_num: 3'")
 	} else {
-		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
+		t.Log(`S<season_num: 3`, "\n\t", err, "\n")
 	}
 
 	err = validate_naming_scheme(`<parent-parent:>`)
@@ -254,7 +248,14 @@ func Test_naming_scheme_validation(t *testing.T) {
 	} else {
 		t.Log(`<parent-parent:>`, "\n\t", err, "\n")
 	}
-
+	
+	err = validate_naming_scheme(`E<episode_num: -2>`)
+	if err == nil {
+		t.Errorf("expected error '-2 is not a valid arg. must be a valid positive integer'")
+	} else {
+		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
+	}
+	
 	err = validate_naming_scheme(`<parent-parent:1>`)
 	if err == nil {
 		t.Errorf("expected error '1 is not a valid arg. must be two valid positive integers separated by a comma'")
@@ -430,5 +431,20 @@ func Test_split_regex_by_pipe(t *testing.T) {
 		for _, part := range parts {
 			t.Log("\t",part, "has only one match group?", has_only_one_match_group(part))
 		}
+	}
+}
+
+
+func Test_generate_new_name(t *testing.T) {
+	path := filepath.Clean(`.test_files\Series\Series_seasonal\Season 1\1234567890.mp4`)
+	t.Log("------------expects success------------")
+	name, err := generate_new_name(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,6>`),
+									2, 1, 3, 2,
+									"title", ".ext",
+									path)
+	if err != nil {
+		t.Error(err)
+	} else {
+		t.Log("\n\told: ", `S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`, "\n\tnew: ", name)
 	}
 }

--- a/parse_args.go
+++ b/parse_args.go
@@ -293,8 +293,8 @@ func validate_naming_scheme(s string) error {
 			// valid range
 			res := strings.SplitN(val, ",", 2)
 			begin, end := strings.TrimSpace(res[0]), strings.TrimSpace(res[1])
-			if begin > end {
-				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than or equal to end (%s)", val, begin, end)
+			if begin >= end {
+				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than end (%s)", val, begin, end)
 			}
 		}
 	}

--- a/rename.go
+++ b/rename.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"sort"
+	"strings"
 )
 
 type Rename interface {
@@ -49,7 +51,6 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		season_path := filepath.Clean(info.path + "/" + season)
-
 
 		fmt.Println("path: ", season_path)
 		files, err := os.ReadDir(season_path)
@@ -113,23 +114,18 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		for i, file := range media_files {
-			var title string
-			if info.series_type == "single_season_no_movies" || info.series_type == "multiple_season_no_movies" || info.series_type == "multiple_season_with_movies" {
-				title = filepath.Base(info.path)
-			} else if info.series_type == "single_season_with_movies" {
-				title = filepath.Base(season_path)
-			} else if info.series_type == "named_seasons" {
-				title = filepath.Base(info.path) + " " + filepath.Base(season_path)
+			title := default_title(info.series_type, info.naming_scheme, info.path, season_path)
+			new_name, err := generate_new_name(info.naming_scheme,
+										  max_season_digits, num, 	// season_pad, season_num
+										  max_ep_digits, ep_nums[i],// ep_pad, ep_num 
+										  title, file) 				// title, file path
+			if err != nil {
+				return err
 			}
-			
-			new_name := fmt.Sprintf("S%0*dE%0*d %s%s",
-									max_season_digits, num, 
-									max_ep_digits, ep_nums[i],
-									clean_title(title), filepath.Ext(file))
 
 			fmt.Println(fmt.Sprintf("%-*s", 20, file), " --> ", fmt.Sprintf("%*s", 20, new_name))
 			fmt.Println("old", season_path+"/"+file, "new", season_path+"/"+new_name)
-			_, err := os.Stat(season_path+new_name)
+			_, err = os.Stat(season_path+new_name)
 			if err == nil {
 				fmt.Println("renaming", season_path+"/"+file, "to", season_path+"/"+new_name + " failed: file already exists")
 				continue
@@ -198,4 +194,120 @@ func (info *MovieInfo) rename() error {
 		}
 	}
 	return nil
+}
+
+func default_title(series_type string, naming_scheme Option[string], path string, season_path string) string {
+	var title string
+	if series_type == "single_season_no_movies" || series_type == "multiple_season_no_movies" || series_type == "multiple_season_with_movies" {
+		title = filepath.Base(path)
+	} else if series_type == "single_season_with_movies" {
+		title = filepath.Base(season_path)
+	} else if series_type == "named_seasons" {
+		title = filepath.Base(path) + " " + filepath.Base(season_path)
+	}
+	return title
+}
+
+func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, file string) (string, error) {
+	var new_name string
+	if naming_scheme.is_some() {
+		scheme, err := naming_scheme.get()
+		if err != nil {
+			return "", err
+		}
+		// replace <season_num>
+		new_name = regexp.MustCompile(`<season_num(\s*:\s*\d+)?>`).ReplaceAllStringFunc(scheme, func(match string) string {
+			// <season_num: \d+>
+			if strings.Contains(match, ":") {
+				pad := regexp.MustCompile(`\d+`).FindString(match)
+				pad_num, err := strconv.Atoi(pad)
+				if err != nil {
+					return match
+				}
+				return fmt.Sprintf("%0*d", pad_num, season_num)
+			}
+			// <season_num>
+			return fmt.Sprintf("%0*d", season_pad, season_num)
+		})
+		// replace <episode_num>
+		new_name = regexp.MustCompile(`<episode_num(\s*:\s*\d+)?>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			// <episode_num: \d+>
+			if strings.Contains(match, ":") {
+				pad := regexp.MustCompile(`\d+`).FindString(match)
+				pad_num, err := strconv.Atoi(pad)
+				if err != nil {
+					return match
+				}
+				return fmt.Sprintf("%0*d", pad_num, ep_num)
+			}
+			// <episode_num>
+			return fmt.Sprintf("%0*d", ep_pad, ep_num)
+		})
+		// replace <self: start,end> with filepath.Base(file)[start:end]
+		new_name = regexp.MustCompile(`<self\s*:\s*\d+,\d+>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
+			if len(parts) != 2 {
+				return match
+			}
+			start, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return match
+			}
+			end, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return match
+			}
+			fmt.Println(filepath.Base(file)[start:end])
+			return filepath.Base(file)[start:end]
+		})
+		// replace <parent> tokens with nth parent's name
+		// lol goodluck: https://regex-vis.com/?r=%3C%28parent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%7Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%29%5Cs*%3E&e=0
+		new_name = regexp.MustCompile(`<(parent(-parent)*(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?|p(-\d+)?(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?)\s*>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			n, err := parent_token_to_int(match)
+			if err != nil {
+				return match
+			}
+			parent_name := nth_parent(file, n)
+
+			if strings.Contains(match, ":") {
+				parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
+
+				if len(parts) == 2 {
+					start, err := strconv.Atoi(parts[0])
+					if err != nil {
+						return parent_name
+					}
+					end, err := strconv.Atoi(parts[1])
+					if err != nil {
+						return parent_name
+					}
+					return parent_name[start:end]
+				}
+				regex_pattern := regexp.MustCompile(`'[^']*'`).FindString(match)
+				if len(regex_pattern) > 0 {
+					regex_pattern = strings.Trim(regex_pattern, "'")
+					re, err := regexp.Compile(regex_pattern)
+					if err != nil {
+						return parent_name
+					}
+					
+					substrings := re.FindStringSubmatch(parent_name)
+					if len(substrings) > 1 {
+						return substrings[1]
+					} 
+				}
+			}
+			return parent_name
+		})
+		// append ext
+		new_name = fmt.Sprintf("%s%s", new_name, filepath.Ext(file))
+
+	} else {
+		new_name = fmt.Sprintf("S%0*dE%0*d %s%s",
+							season_pad, season_num, 
+							ep_pad, ep_num,
+							title, filepath.Ext(file))
+	}
+
+	return new_name, nil
 }

--- a/rename.go
+++ b/rename.go
@@ -19,6 +19,7 @@ type SeriesInfo struct {
 	movies          []string
 	keep_ep_nums    Option[bool]
 	starting_ep_num Option[int]
+	naming_scheme   Option[string]
 }
 
 type MovieInfo struct {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool]) (SeriesInfo, error) {
+func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool], naming_scheme Option[string]) (SeriesInfo, error) {
 	// get prerequsite info for renaming series
 	info := SeriesInfo{
 		path: 				path,

--- a/utils.go
+++ b/utils.go
@@ -208,3 +208,41 @@ func has_only_one_match_group (s string) bool {
 
 	return matchGroupCount == 1
 }
+
+func parent_token_to_int(s string) (int, error) {
+	// lmao https://regex-vis.com/?r=%3Cparent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd+%5Cs*%2C%5Cs*%5Cd+%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
+	long_form := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d \s*,\s*\d )|('[^']*')))?\s*>`)
+	// lul https://regex-vis.com/?r=%3Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%5Cs*%2C%5Cs*%5Cd%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
+	short_form := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d\s*,\s*\d)|('[^']*')))?\s*>`)
+	
+	if long_form.MatchString(s) {
+		return strings.Count(s, "parent"), nil
+		
+	} else if short_form.MatchString(s) {
+		// only p
+		single_p := regexp.MustCompile(`p\s*:`)
+		if single_p.MatchString(s) {
+			return 1, nil
+		}
+		// p-int
+		match_num := regexp.MustCompile(`p-(\d+)`).FindStringSubmatch(s)
+		if len(match_num) != 2 {
+			return 0, fmt.Errorf("invalid parent token: %s", s)
+		}
+		num, err := strconv.Atoi(match_num[1])
+		if err != nil {
+			return 0, err
+		}
+		return num, nil
+
+	} else {
+		return 0, fmt.Errorf("invalid parent token: %s", s)
+	}
+}
+
+func nth_parent(path string, n int) string {
+	for i := 0; i < n; i++ {
+		path = filepath.Dir(path)
+	}
+	return filepath.Base(path)
+}


### PR DESCRIPTION
closes #11 

### changes
1. add naming scheme field to `SeriesInfo`
2. disallow range with begin index being equal to end range
### new
1. naming scheme now affects renaming if present.
    - it takes the naming scheme string and replaces the tokens enclosed in `<>` and replaces it with proper values
    - rip to readers, I used regex. I'll refactor to just string manipulation next time
    - new tests for this too, even parsing and using user inputted regex pattern