### PR TITLE
prompt user for additional options + new --options flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -31,15 +31,15 @@ func main() {
 			fmt.Println("\t", movie)
 		}
 	}
-	ken, err := args.keep_ep_nums.get()
+	ken, err := args.options.has_season_0.get()
 	if err == nil {
 		fmt.Println("keep episode numbers: ", ken)
 	}
-	sen, err := args.starting_ep_num.get()
+	sen, err := args.options.has_season_0.get()
 	if err == nil {
 		fmt.Println("starting episode number: ", sen)
 	}
-	ns, err := args.naming_scheme.get()
+	ns, err := args.options.has_season_0.get()
 	if err == nil {
 		fmt.Println("naming scheme: ", ns)
 	}
@@ -104,10 +104,9 @@ func main() {
 	}
 
 	fmt.Println("test for named seasons")
-	named_season_ken, named_season_sen, named_season_s0, named_season_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&named_season_ken, &named_season_sen, &named_season_s0, &named_season_ns, "named seasons")
+	named_season_options := prompt_additional_options(args.options, "all named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", named_season_ken, named_season_sen, named_season_s0, named_season_ns)
+		info, err := series_rename_prereqs(v, "named_seasons", named_season_options)
 		if err != nil {
 			panic(err)
 		}
@@ -121,10 +120,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season no movies")
-	ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&ssnm_ken, &ssnm_sen, &ssnm_s0, &ssnm_ns, "single season no movies")
+	ssnm_options := prompt_additional_options(args.options, "all single season with no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns)
+		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_options)
 		if err != nil {
 			panic(err)
 		}
@@ -138,10 +136,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season with movies")
-	sswm_ken, sswm_sen, sswm_s0, sswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&sswm_ken, &sswm_sen, &sswm_s0, &sswm_ns, "single season with movies")
+	sswm_options := prompt_additional_options(args.options, "all single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_ken, sswm_sen, sswm_s0, sswm_ns)
+		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_options)
 		if err != nil {
 			panic(err)
 		}
@@ -155,10 +152,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season no movies")
-	msnm_ken, msnm_sen, msnm_s0, msnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&msnm_ken, &msnm_sen, &msnm_s0, &msnm_ns, "multiple season no movies")
+	msnm_options := prompt_additional_options(args.options, "all multiple season with no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_ken, msnm_sen, msnm_s0, msnm_ns)
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_options)
 		if err != nil {
 			panic(err)
 		}
@@ -172,10 +168,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season with movies")
-	mswm_ken, mswm_sen, mswm_s0, mswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&mswm_ken, &mswm_sen, &mswm_s0, &mswm_ns, "multiple season with movies")
+	mswm_options := prompt_additional_options(args.options, "all multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_ken, mswm_sen, mswm_s0, mswm_ns)
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_options)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -104,8 +104,10 @@ func main() {
 	}
 
 	fmt.Println("test for named seasons")
+	named_season_ken, named_season_sen, named_season_s0, named_season_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&named_season_ken, &named_season_sen, &named_season_s0, &named_season_ns, "named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "named_seasons", named_season_ken, named_season_sen, named_season_s0, named_season_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -117,10 +119,13 @@ func main() {
 		}
 	}
 	fmt.Println()
+	// panic("test")
 
 	fmt.Println("test for single season no movies")
+	ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&ssnm_ken, &ssnm_sen, &ssnm_s0, &ssnm_ns, "single season no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true), none[string]())
+		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -134,8 +139,10 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season with movies")
+	sswm_ken, sswm_sen, sswm_s0, sswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&sswm_ken, &sswm_sen, &sswm_s0, &sswm_ns, "single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_ken, sswm_sen, sswm_s0, sswm_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -149,8 +156,10 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season no movies")
+	msnm_ken, msnm_sen, msnm_s0, msnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&msnm_ken, &msnm_sen, &msnm_s0, &msnm_ns, "multiple season no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_ken, msnm_sen, msnm_s0, msnm_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -164,8 +173,10 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season with movies")
+	mswm_ken, mswm_sen, mswm_s0, mswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&mswm_ken, &mswm_sen, &mswm_s0, &mswm_ns, "multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_ken, mswm_sen, mswm_s0, mswm_ns)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -119,7 +119,6 @@ func main() {
 		}
 	}
 	fmt.Println()
-	// panic("test")
 
 	fmt.Println("test for single season no movies")
 	ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme

--- a/main_test.go
+++ b/main_test.go
@@ -443,12 +443,12 @@ func Test_generate_new_name(t *testing.T) {
 									2, 1, 3, 2,
 									"title", path)
 	if err != nil {
-		t.Error(err)
+		t.Error("expected no error; got", err)
 	} else {
-		if strings.ReplaceAll(name, "S001E02 - Series Season ies 6.mp4", "") != "" {
-			t.Errorf("expected 'S001E02 - Series Season ies 6.mp4' got '%s'", name)
+		if strings.ReplaceAll(name, `.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4`, "") != "" {
+			t.Errorf(`expected '.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4' got '%s'`, name)
 		} else {
-			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: '.*r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
+			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -342,6 +342,13 @@ func Test_naming_scheme_validation(t *testing.T) {
 	} else {
 		t.Log(`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`)
 	}
+
+	err = validate_naming_scheme(`<p> <p-2>`)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(`<p>`)
+	}
 }
 
 func Test_split_regex_by_pipe(t *testing.T) {
@@ -444,4 +451,18 @@ func Test_generate_new_name(t *testing.T) {
 			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
 		}
 	}
+
+	name, err = generate_new_name(some[string](`<p>`), 
+									2, 1, 3, 2, 
+									"title", path)
+	if err != nil {
+		t.Error("expected no error; got", err)
+	} else {
+		if strings.ReplaceAll(name, `.test_files\Series\Series_seasonal\Season 1\Season 1.mp4`, "") != "" {
+			t.Errorf(`expected '.test_files\Series\Series_seasonal\Season 1\Season 1.mp4' got '%s'`, name)
+		} else {
+			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `<p> <p-2>`, "\n\tnew:\t\t", name)
+		}
+	}
+
 }

--- a/main_test.go
+++ b/main_test.go
@@ -116,7 +116,7 @@ func Test_parse_args(t *testing.T) {
 	command = []string{"-r", "./test_files", "--season-0", "-s0"}
 	_, err = parse_args(command)
 	if err == nil {
-		t.Errorf("expected error '-s0 is not a valid arg. must be all or var'")
+		t.Errorf("expected error 'only one of --season-0 and -s0 is allowed'")
 	} else {
 		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
 	}
@@ -186,13 +186,13 @@ func Test_parse_args(t *testing.T) {
 	}
 	
 	
-		command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
-		_, err = parse_args(command)
-		if err == nil {
-			t.Errorf("expected error 'multiple starting-ep-num flags'")
-		} else {
-			t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
-		}
+	command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'multiple starting-ep-num flags'")
+	} else {
+		t.Log("-r", "./test_files", "--naming-scheme", "S01E01", "\n\t", err, "\n")
+	}
 	t.Log("------------expects success------------")
 	
 	command = []string{"--root", "./test_files", "-s0", "all", "yes"}

--- a/main_test.go
+++ b/main_test.go
@@ -257,13 +257,6 @@ func Test_naming_scheme_validation(t *testing.T) {
 		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
 	}
 	
-	err = validate_naming_scheme(`<parent-parent:1>`)
-	if err == nil {
-		t.Errorf("expected error '1 is not a valid arg. must be two valid positive integers separated by a comma'")
-	} else {
-		t.Log(`<parent-parent:1>`, "\n\t", err, "\n")
-	}
-
 	err = validate_naming_scheme(`<parent-parent:1,>`)
 	if err == nil {
 		t.Errorf("expected error '1, is not a valid arg. must be two valid positive integers separated by a comma'")

--- a/parse_args.go
+++ b/parse_args.go
@@ -48,6 +48,9 @@ func parse_args(args []string) (Args, error) {
 		"--movies": true,
 		"-m":       true,
 	}
+	assigned := map[string]bool {
+		"--options": false,
+	}
 
 	parsed_args := new_Args()
 	skip_iter := 0
@@ -178,6 +181,31 @@ func parse_args(args []string) (Args, error) {
 				parsed_args.options.starting_ep_num = none[int]()
 			}
 
+		} else if arg == "--options" || arg == "-o" {
+			if assigned["--options"] {
+				return Args{}, fmt.Errorf("only one --options flag is allowed")
+			}
+			
+			// all options are assigned `var`
+			if len(args) <= i+1 || (len(args) > i+1 && (args[i+1][0] == '-' || args[i+1] == "var")) {
+				assigned["--options"] = true
+				parsed_args.options.keep_ep_nums = none[bool]()
+				parsed_args.options.starting_ep_num = none[int]()
+				parsed_args.options.has_season_0 = none[bool]()
+				parsed_args.options.naming_scheme = none[string]()
+
+			} else if args[i+1] != "default" && args[i+1] != "var" {
+				return Args{}, fmt.Errorf("invalid value '%s' for --options. Must be 'default' or 'var", args[i+1])
+
+			} else if args[i+1] == "default" {
+				// use default values
+				assigned["--options"] = true
+				parsed_args.options.keep_ep_nums = some[bool](false)
+				parsed_args.options.starting_ep_num = some[int](1)
+				parsed_args.options.has_season_0 = some[bool](false)
+				parsed_args.options.naming_scheme = some[string]("default")
+			}
+
 		} else if arg == "--naming-scheme" || arg == "-ns" {
 			if parsed_args.options.naming_scheme.is_some() {
 				return Args{}, fmt.Errorf("only one --naming-scheme flag is allowed")
@@ -215,18 +243,20 @@ func parse_args(args []string) (Args, error) {
 		return Args{}, err
 	}
 
-	// use default values for additional options
-	if parsed_args.options.has_season_0.is_none() {
-		parsed_args.options.has_season_0 = some[bool](false)
-	}
-	if parsed_args.options.keep_ep_nums.is_none() {
-		parsed_args.options.keep_ep_nums = some[bool](false)
-	}
-	if parsed_args.options.starting_ep_num.is_none() {
-		parsed_args.options.starting_ep_num = some[int](1)
-	}
-	if parsed_args.options.naming_scheme.is_none() {
-		parsed_args.options.naming_scheme = some[string]("default")
+	if !assigned["--options"] {
+		// use default values for additional options
+		if parsed_args.options.has_season_0.is_none() {
+			parsed_args.options.has_season_0 = some[bool](false)
+		}
+		if parsed_args.options.keep_ep_nums.is_none() {
+			parsed_args.options.keep_ep_nums = some[bool](false)
+		}
+		if parsed_args.options.starting_ep_num.is_none() {
+			parsed_args.options.starting_ep_num = some[int](1)
+		}
+		if parsed_args.options.naming_scheme.is_none() {
+			parsed_args.options.naming_scheme = some[string]("default")
+		}
 	}
 	return parsed_args, nil
 }

--- a/parse_args.go
+++ b/parse_args.go
@@ -226,9 +226,8 @@ func parse_args(args []string) (Args, error) {
 		parsed_args.options.starting_ep_num = some[int](1)
 	}
 	if parsed_args.options.naming_scheme.is_none() {
-		parsed_args.options.naming_scheme = none[string]()
+		parsed_args.options.naming_scheme = some[string]("default")
 	}
-
 	return parsed_args, nil
 }
 

--- a/parse_args.go
+++ b/parse_args.go
@@ -293,7 +293,7 @@ func validate_naming_scheme(s string) error {
 			// valid range
 			res := strings.SplitN(val, ",", 2)
 			begin, end := strings.TrimSpace(res[0]), strings.TrimSpace(res[1])
-			if begin >= end {
+			if begin > end {
 				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than end (%s)", val, begin, end)
 			}
 		}

--- a/parse_args.go
+++ b/parse_args.go
@@ -221,7 +221,7 @@ func validate_naming_scheme(s string) error {
 
 	valid_api := regexp.MustCompile(`^season_num$|^episode_num$|^self$`)
 	valid_parent_api := regexp.MustCompile(`^parent(-parent)*$|^p(-\d+)?$`)
-	valid_range := regexp.MustCompile(`^\d+(,\s*\d+)?$`)
+	valid_range := regexp.MustCompile(`^\d+(\s*,\s*\d+)?$`)
 
 	for _,token := range tokens {
 		var api, val string

--- a/parse_args.go
+++ b/parse_args.go
@@ -10,12 +10,15 @@ import (
 )
 
 type Args struct {
-	root            []string
-	series          []string
-	movies          []string
-	has_season_0    Option[bool]
+	root            	[]string
+	series          	[]string
+	movies          	[]string
+	options 	AdditionalOptions
+}
+type AdditionalOptions struct {
 	keep_ep_nums    Option[bool]
 	starting_ep_num Option[int]
+	has_season_0    Option[bool]
 	naming_scheme   Option[string]
 }
 func new_Args() Args {
@@ -23,10 +26,12 @@ func new_Args() Args {
 		root:            make([]string, 0),
 		series:          make([]string, 0),
 		movies:          make([]string, 0),
-		has_season_0:    none[bool](),
-		keep_ep_nums:    none[bool](),
-		starting_ep_num: none[int](),
-		naming_scheme:   none[string](),
+		options: AdditionalOptions{
+			has_season_0:    none[bool](),
+			keep_ep_nums:    none[bool](),
+			starting_ep_num: none[int](),
+			naming_scheme:   none[string](),
+		},
 	}
 }
 
@@ -80,13 +85,13 @@ func parse_args(args []string) (Args, error) {
 			skip_iter = i + 1
 
 		} else if arg == "--season-0" || arg == "-s0" {
-			if parsed_args.has_season_0.is_some() {
+			if parsed_args.options.has_season_0.is_some() {
 				return Args{}, fmt.Errorf("only one --season-0 flag is allowed")
 			}
 
 			// default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.has_season_0 = some[bool](false)
+				parsed_args.options.has_season_0 = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'all' or 'var", args[i+1], arg)
@@ -104,21 +109,21 @@ func parse_args(args []string) (Args, error) {
 				} else {
 					value = false
 				}
-				parsed_args.has_season_0 = some[bool](value)
+				parsed_args.options.has_season_0 = some[bool](value)
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.has_season_0 = none[bool]()
+				parsed_args.options.has_season_0 = none[bool]()
 			}
 
 		} else if arg == "--keep-ep-nums" || arg == "-ken" {
-			if parsed_args.keep_ep_nums.is_some() {
+			if parsed_args.options.keep_ep_nums.is_some() {
 				return Args{}, fmt.Errorf("only one --keep-ep-nums flag is allowed")
 			}
 
 			// default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.keep_ep_nums = some[bool](false)
+				parsed_args.options.keep_ep_nums = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'all' or 'var", args[i+1])
@@ -137,21 +142,21 @@ func parse_args(args []string) (Args, error) {
 				} else {
 					value = false
 				}
-				parsed_args.keep_ep_nums = some[bool](value)
+				parsed_args.options.keep_ep_nums = some[bool](value)
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.has_season_0 = none[bool]()
+				parsed_args.options.has_season_0 = none[bool]()
 			}
 
 		} else if arg == "--starting-ep-num" || arg == "-sen" {
-			if parsed_args.starting_ep_num.is_some() {
+			if parsed_args.options.starting_ep_num.is_some() {
 				return Args{}, fmt.Errorf("only one --starting-ep-num flag is allowed")
 			}
 
 			// default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.starting_ep_num = some[int](1)
+				parsed_args.options.starting_ep_num = some[int](1)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be 'all' or 'var", args[i+1])
@@ -166,15 +171,15 @@ func parse_args(args []string) (Args, error) {
 					return Args{}, fmt.Errorf("all must be followed by a positive int for --starting-ep-num. %s is not a valid positive int", args[i+2])
 				}
 
-				parsed_args.starting_ep_num = some[int](value)
+				parsed_args.options.starting_ep_num = some[int](value)
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.starting_ep_num = none[int]()
+				parsed_args.options.starting_ep_num = none[int]()
 			}
 
 		} else if arg == "--naming-scheme" || arg == "-ns" {
-			if parsed_args.naming_scheme.is_some() {
+			if parsed_args.options.naming_scheme.is_some() {
 				return Args{}, fmt.Errorf("only one --naming-scheme flag is allowed")
 			}
 
@@ -193,11 +198,11 @@ func parse_args(args []string) (Args, error) {
 					return Args{}, err
 				}
 
-				parsed_args.naming_scheme = some[string](args[i+2])
+				parsed_args.options.naming_scheme = some[string](args[i+2])
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.naming_scheme = none[string]()
+				parsed_args.options.naming_scheme = none[string]()
 			}
 
 		} else {

--- a/parse_args.go
+++ b/parse_args.go
@@ -89,9 +89,9 @@ func parse_args(args []string) (Args, error) {
 				return Args{}, fmt.Errorf("only one --season-0 flag is allowed")
 			}
 
-			// default value
+			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.options.has_season_0 = some[bool](false)
+				continue
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'all' or 'var", args[i+1], arg)
@@ -121,9 +121,9 @@ func parse_args(args []string) (Args, error) {
 				return Args{}, fmt.Errorf("only one --keep-ep-nums flag is allowed")
 			}
 
-			// default value
+			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.options.keep_ep_nums = some[bool](false)
+				continue
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'all' or 'var", args[i+1])
@@ -154,9 +154,9 @@ func parse_args(args []string) (Args, error) {
 				return Args{}, fmt.Errorf("only one --starting-ep-num flag is allowed")
 			}
 
-			// default value
+			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.options.starting_ep_num = some[int](1)
+				continue
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be 'all' or 'var", args[i+1])
@@ -213,6 +213,20 @@ func parse_args(args []string) (Args, error) {
 	err := validate_roots(parsed_args.root, parsed_args.series, parsed_args.movies)
 	if err != nil {
 		return Args{}, err
+	}
+
+	// use default values for additional options
+	if parsed_args.options.has_season_0.is_none() {
+		parsed_args.options.has_season_0 = some[bool](false)
+	}
+	if parsed_args.options.keep_ep_nums.is_none() {
+		parsed_args.options.keep_ep_nums = some[bool](false)
+	}
+	if parsed_args.options.starting_ep_num.is_none() {
+		parsed_args.options.starting_ep_num = some[int](1)
+	}
+	if parsed_args.options.naming_scheme.is_none() {
+		parsed_args.options.naming_scheme = none[string]()
 	}
 
 	return parsed_args, nil

--- a/parse_args.go
+++ b/parse_args.go
@@ -56,7 +56,7 @@ func parse_args(args []string) (Args, error) {
 		if skip_iter != 0 && i <= skip_iter {
 			continue
 
-			// catch invalid values acting as flags
+		// catch invalid values acting as flags
 		} else if arg[0] != '-' {
 			return Args{}, fmt.Errorf("invalid flag: '%s'", arg)
 
@@ -65,7 +65,7 @@ func parse_args(args []string) (Args, error) {
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
 				return Args{}, fmt.Errorf("missing dir path value for flag '%s'", arg)
 
-				// not a valid directory
+			// not a valid directory
 			} else if _, err := filepath.Abs(args[i+1]); err != nil {
 				return Args{}, err
 			}
@@ -91,7 +91,7 @@ func parse_args(args []string) (Args, error) {
 
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				continue
+				parsed_args.options.has_season_0 = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'all' or 'var", args[i+1], arg)
@@ -123,7 +123,7 @@ func parse_args(args []string) (Args, error) {
 
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				continue
+				parsed_args.options.keep_ep_nums = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'all' or 'var", args[i+1])
@@ -156,7 +156,7 @@ func parse_args(args []string) (Args, error) {
 
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				continue
+				parsed_args.options.starting_ep_num = some[int](1)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be 'all' or 'var", args[i+1])

--- a/parse_args.go
+++ b/parse_args.go
@@ -221,7 +221,7 @@ func validate_naming_scheme(s string) error {
 
 	valid_api := regexp.MustCompile(`^season_num$|^episode_num$|^self$`)
 	valid_parent_api := regexp.MustCompile(`^parent(-parent)*$|^p(-\d+)?$`)
-	valid_range := regexp.MustCompile(`^\d+,\s*\d+$`)
+	valid_range := regexp.MustCompile(`^\d+(,\s*\d+)?$`)
 
 	for _,token := range tokens {
 		var api, val string
@@ -290,11 +290,17 @@ func validate_naming_scheme(s string) error {
 			} else if !valid_range.MatchString(val) {
 				return fmt.Errorf("%s's value must be in the format <start>,<end> where <start> and <end> are positive integers and 0. '%s' is not a valid range", api, val)
 			}
+
 			// valid range
-			res := strings.SplitN(val, ",", 2)
+			var res []string
+			if strings.Contains(val, ",") {
+				res = strings.SplitN(val, ",", 2)
+			} else {
+				res = []string{val, val}
+			}
 			begin, end := strings.TrimSpace(res[0]), strings.TrimSpace(res[1])
 			if begin > end {
-				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than end (%s)", val, begin, end)
+				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than or equal to end (%s)", val, begin, end)
 			}
 		}
 	}

--- a/rename.go
+++ b/rename.go
@@ -77,12 +77,12 @@ func (info *SeriesInfo) rename() error {
 		season_ken, season_sen, season_s0, season_ns := info.keep_ep_nums, info.starting_ep_num, some[bool](false), info.naming_scheme
 		prompt_additional_options(&season_ken, &season_sen, &season_s0, &season_ns, season_path)
 
-		var ep_num int
-		sen, err := season_sen.get()
-		if err != nil {
-			return err
+		var ep_num, sen int
+		if season_sen.is_some() {
+			sen, _ = season_sen.get()
+		} else {
+			sen = 1
 		}
-
 		if sen > 0 {
 			ep_num = sen
 		} else {
@@ -90,9 +90,11 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		ep_nums := make([]int, 0)
-		ken, err := season_ken.get()
-		if err != nil {
-			return err
+		var ken bool
+		if season_ken.is_some() {
+			ken, _ = season_ken.get()
+		} else {
+			ken = false
 		}
 
 		if ken {

--- a/rename.go
+++ b/rename.go
@@ -326,6 +326,7 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 							season_pad, season_num, 
 							ep_pad, ep_num,
 							title, filepath.Ext(abs_path))
+		new_name = filepath.Join(filepath.Dir(abs_path), new_name)
 	}
 
 	return new_name, nil

--- a/rename.go
+++ b/rename.go
@@ -73,8 +73,12 @@ func (info *SeriesInfo) rename() error {
 			max_ep_digits = 2
 		}
 		
+		// if additional options are none aka user inputted var, ask for user input
+		season_ken, season_sen, season_s0, season_ns := info.keep_ep_nums, info.starting_ep_num, some[bool](false), info.naming_scheme
+		prompt_additional_options(&season_ken, &season_sen, &season_s0, &season_ns, season_path)
+
 		var ep_num int
-		sen, err := info.starting_ep_num.get()
+		sen, err := season_sen.get()
 		if err != nil {
 			return err
 		}
@@ -86,7 +90,7 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		ep_nums := make([]int, 0)
-		ken, err := info.keep_ep_nums.get()
+		ken, err := season_ken.get()
 		if err != nil {
 			return err
 		}
@@ -114,11 +118,11 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		for i, file := range media_files {
-			title := default_title(info.series_type, info.naming_scheme, info.path, season_path)
-			new_name, err := generate_new_name(info.naming_scheme,
-										  max_season_digits, num, 	// season_pad, season_num
-										  max_ep_digits, ep_nums[i],// ep_pad, ep_num 
-										  title, file) 				// title, file path
+			title := default_title(info.series_type, season_ns, info.path, season_path)
+			new_name, err := generate_new_name(season_ns,				// naming_scheme
+										  max_season_digits, num, 		// season_pad, season_num
+										  max_ep_digits, ep_nums[i],	// ep_pad, ep_num 
+										  title, file) 					// title, file path
 			if err != nil {
 				return err
 			}

--- a/rename.go
+++ b/rename.go
@@ -213,6 +213,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 
 func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {
 	var new_name string
+	ns, _ := naming_scheme.get()
 	if naming_scheme.is_some() {
 		scheme, err := naming_scheme.get()
 		if err != nil {
@@ -320,7 +321,7 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 		// append ext
 		new_name = filepath.Join(filepath.Dir(abs_path), fmt.Sprintf("%s%s", new_name, filepath.Ext(abs_path)))
 
-	} else {
+	} else if naming_scheme.is_none() || ns == "default"{
 		new_name = fmt.Sprintf("S%0*dE%0*d %s%s",
 							season_pad, season_num, 
 							ep_pad, ep_num,

--- a/rename.go
+++ b/rename.go
@@ -51,20 +51,20 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		season_path := filepath.Clean(info.path + "/" + season)
-
 		fmt.Println("path: ", season_path)
-		files, err := os.ReadDir(season_path)
+
+		var media_files []string
+		err := filepath.WalkDir(season_path, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && is_media_file(d.Name()) {
+				media_files = append(media_files, path)
+			}
+			return nil
+		})
 		if err != nil {
 			return err
-		}
-		media_files := make([]string, 0)
-		for _, file := range files {
-			if file.IsDir() {
-				continue
-			}
-			if is_media_file(file.Name()) {
-				media_files = append(media_files, file.Name())
-			}
 		}
 		sort.Sort(FilenameSort(media_files))
 
@@ -124,17 +124,17 @@ func (info *SeriesInfo) rename() error {
 			}
 
 			fmt.Println(fmt.Sprintf("%-*s", 20, file), " --> ", fmt.Sprintf("%*s", 20, new_name))
-			fmt.Println("old", season_path+"/"+file, "new", season_path+"/"+new_name)
-			_, err = os.Stat(season_path+new_name)
+			fmt.Println("old", file, "\nnew", new_name)
+			_, err = os.Stat(new_name)
 			if err == nil {
-				fmt.Println("renaming", season_path+"/"+file, "to", season_path+"/"+new_name + " failed: file already exists")
+				fmt.Println("renaming", filepath.Base(file), "to", filepath.Base(new_name) + " failed: file already exists")
 				continue
 			} else if os.IsNotExist(err) {
-				err = os.Rename(season_path+"/"+file, season_path+"/"+new_name)
+				err = os.Rename(file, new_name)
+				if err != nil {
+					return err
+				}
 			} else {
-				return err
-			}
-			if err != nil {
 				return err
 			}
 		}
@@ -208,7 +208,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 	return title
 }
 
-func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, file string) (string, error) {
+func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {
 	var new_name string
 	if naming_scheme.is_some() {
 		scheme, err := naming_scheme.get()
@@ -220,10 +220,7 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 			// <season_num: \d+>
 			if strings.Contains(match, ":") {
 				pad := regexp.MustCompile(`\d+`).FindString(match)
-				pad_num, err := strconv.Atoi(pad)
-				if err != nil {
-					return match
-				}
+				pad_num, _ := strconv.Atoi(pad)
 				return fmt.Sprintf("%0*d", pad_num, season_num)
 			}
 			// <season_num>
@@ -234,79 +231,97 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 			// <episode_num: \d+>
 			if strings.Contains(match, ":") {
 				pad := regexp.MustCompile(`\d+`).FindString(match)
-				pad_num, err := strconv.Atoi(pad)
-				if err != nil {
-					return match
-				}
+				pad_num, _ := strconv.Atoi(pad)
 				return fmt.Sprintf("%0*d", pad_num, ep_num)
 			}
 			// <episode_num>
 			return fmt.Sprintf("%0*d", ep_pad, ep_num)
 		})
-		// replace <self: start,end> with filepath.Base(file)[start:end]
+		// replace <self>
 		new_name = regexp.MustCompile(`<self\s*:\s*\d+,\d+>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			// if error, return full base name without extension
+			base_name := filepath.Base(abs_path)
+			base_name = strings.ReplaceAll(base_name, filepath.Ext(base_name), "")
+
 			parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
 			if len(parts) != 2 {
-				return match
+				return base_name
 			}
 			start, err := strconv.Atoi(parts[0])
-			if err != nil {
-				return match
+			if err != nil || start >= len(base_name) {
+				return base_name
 			}
 			end, err := strconv.Atoi(parts[1])
-			if err != nil {
-				return match
+			if err != nil || end+1 >= len(base_name) {
+				return base_name
 			}
-			fmt.Println(filepath.Base(file)[start:end])
-			return filepath.Base(file)[start:end]
+			return base_name[start:end+1]
 		})
 		// replace <parent> tokens with nth parent's name
 		// lol goodluck: https://regex-vis.com/?r=%3C%28parent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%7Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%29%5Cs*%3E&e=0
-		new_name = regexp.MustCompile(`<(parent(-parent)*(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?|p(-\d+)?(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?)\s*>`).ReplaceAllStringFunc(new_name, func(match string) string {
+		new_name = regexp.MustCompile(`<(parent(-parent)*(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?|p(-\d+)?(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?)\s*>`).ReplaceAllStringFunc(new_name, func(match string) string {
 			n, err := parent_token_to_int(match)
 			if err != nil {
-				return match
+				return new_name
 			}
-			parent_name := nth_parent(file, n)
+			parent_name := nth_parent(abs_path, n)
 
-			if strings.Contains(match, ":") {
-				parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
+			// <parent>
+			if !strings.Contains(match, ":") {return parent_name}
 
-				if len(parts) == 2 {
-					start, err := strconv.Atoi(parts[0])
-					if err != nil {
-						return parent_name
-					}
-					end, err := strconv.Atoi(parts[1])
-					if err != nil {
-						return parent_name
-					}
-					return parent_name[start:end]
+			// has ':'
+			// <parent: <value>>
+			trimmed_match := strings.Trim(match, "<>")
+			val := strings.TrimSpace(strings.SplitN(trimmed_match, ":", 2)[1])
+			switch val[0] {
+			// <parent: 1,2>
+			case ',':
+				val := strings.SplitN(val, ",", 2)
+				start, err := strconv.Atoi(val[0])
+				if err != nil || start >= len(parent_name) {
+					return parent_name
 				}
-				regex_pattern := regexp.MustCompile(`'[^']*'`).FindString(match)
-				if len(regex_pattern) > 0 {
-					regex_pattern = strings.Trim(regex_pattern, "'")
-					re, err := regexp.Compile(regex_pattern)
-					if err != nil {
-						return parent_name
-					}
-					
-					substrings := re.FindStringSubmatch(parent_name)
-					if len(substrings) > 1 {
-						return substrings[1]
-					} 
+				end, err := strconv.Atoi(val[1])
+				if err != nil || end+1 >= len(parent_name) {
+					return parent_name
 				}
+				return parent_name[start:end+1]
+
+			// <parent: '<regex_pattern>'>
+			case '\'':
+				regex_pattern := strings.Trim(val, "'")
+				_, err := regexp.Compile(regex_pattern)
+				if err != nil {
+					return parent_name
+				}
+				sub_regexes := split_regex_by_pipe(regex_pattern)
+				for _, re := range sub_regexes {
+					sub_match := regexp.MustCompile(re).FindStringSubmatch(parent_name)
+					if len(sub_match) > 1 {
+						// found a substring match
+						return sub_match[1]
+					}
+				}
+				// did not find a substring match
+				return parent_name
+
+			// <parent: 1>
+			default:
+				start, err := strconv.Atoi(val)
+				if err != nil || start+1 >= len(parent_name) {
+					return parent_name
+				}
+				return parent_name[start:start+1]
 			}
-			return parent_name
 		})
 		// append ext
-		new_name = fmt.Sprintf("%s%s", new_name, filepath.Ext(file))
+		new_name = filepath.Join(filepath.Dir(abs_path), fmt.Sprintf("%s%s", new_name, filepath.Ext(abs_path)))
 
 	} else {
 		new_name = fmt.Sprintf("S%0*dE%0*d %s%s",
 							season_pad, season_num, 
 							ep_pad, ep_num,
-							title, filepath.Ext(file))
+							title, filepath.Ext(abs_path))
 	}
 
 	return new_name, nil

--- a/rename.go
+++ b/rename.go
@@ -208,7 +208,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 	} else if series_type == "named_seasons" {
 		title = filepath.Base(path) + " " + filepath.Base(season_path)
 	}
-	return title
+	return clean_title(title)
 }
 
 func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {

--- a/rename.go
+++ b/rename.go
@@ -19,9 +19,7 @@ type SeriesInfo struct {
 	series_type     string
 	seasons         map[int]string
 	movies          []string
-	keep_ep_nums    Option[bool]
-	starting_ep_num Option[int]
-	naming_scheme   Option[string]
+	options         AdditionalOptions
 }
 
 type MovieInfo struct {
@@ -74,12 +72,11 @@ func (info *SeriesInfo) rename() error {
 		}
 		
 		// if additional options are none aka user inputted var, ask for user input
-		season_ken, season_sen, season_s0, season_ns := info.keep_ep_nums, info.starting_ep_num, some[bool](false), info.naming_scheme
-		prompt_additional_options(&season_ken, &season_sen, &season_s0, &season_ns, season_path)
+		season_options := prompt_additional_options(info.options, season_path)
 
 		var ep_num, sen int
-		if season_sen.is_some() {
-			sen, _ = season_sen.get()
+		if season_options.starting_ep_num.is_some() {
+			sen, _ = season_options.starting_ep_num.get()
 		} else {
 			sen = 1
 		}
@@ -91,8 +88,8 @@ func (info *SeriesInfo) rename() error {
 
 		ep_nums := make([]int, 0)
 		var ken bool
-		if season_ken.is_some() {
-			ken, _ = season_ken.get()
+		if season_options.keep_ep_nums.is_some() {
+			ken, _ = season_options.keep_ep_nums.get()
 		} else {
 			ken = false
 		}
@@ -120,11 +117,11 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		for i, file := range media_files {
-			title := default_title(info.series_type, season_ns, info.path, season_path)
-			new_name, err := generate_new_name(season_ns,				// naming_scheme
-										  max_season_digits, num, 		// season_pad, season_num
-										  max_ep_digits, ep_nums[i],	// ep_pad, ep_num 
-										  title, file) 					// title, file path
+			title := default_title(info.series_type, season_options.naming_scheme, info.path, season_path)
+			new_name, err := generate_new_name(season_options.naming_scheme,// naming_scheme
+											   max_season_digits, num, 		// season_pad, season_num
+										  	   max_ep_digits, ep_nums[i],	// ep_pad, ep_num 
+										  	   title, file)					// title, file path
 			if err != nil {
 				return err
 			}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -55,6 +55,10 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 }
 
 func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Option[int], has_season_0 *Option[bool], naming_scheme *Option[string], path string) {
+	default_ken := some[bool](false)
+	default_sen := some[int](1)
+	default_s0 := some[bool](false)
+
 	// prompt user for additional options
 	if (*keep_ep_nums).is_none() {
 		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\ninputs: (y/n/var/default/exit)")
@@ -68,8 +72,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					(*keep_ep_nums) = some[bool](true)
 				case "n", "no":
 					(*keep_ep_nums) = some[bool](false)
-				case "var", "default":
+				case "var", "exit":
 					break
+				case "default":
+					(*keep_ep_nums) = default_ken
 				default:
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
 					continue
@@ -91,7 +97,9 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				}
 
 				switch input {
-				case "var", "default", "exit":
+				case "default":
+					(*starting_ep_num) = default_sen
+				case "var", "exit":
 					break
 				default:
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
@@ -112,8 +120,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					(*has_season_0) = some[bool](true)
 				case "n", "no":
 					(*has_season_0) = some[bool](false)
-				case "var", "default", "exit":
+				case "var", "exit":
 					break
+				case "default":
+					(*has_season_0) = default_s0
 				default:
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
 					continue

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -67,18 +67,19 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 			if scanner.Scan() {
 				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
 
-				switch input {
-				case "y", "yes":
+				if input == "y" || input == "yes" {
 					(*keep_ep_nums) = some[bool](true)
-				case "n", "no":
-					(*keep_ep_nums) = some[bool](false)
-				case "var", "exit":
 					break
-				case "default":
+				} else if input == "n" || input == "no" {
+					(*keep_ep_nums) = some[bool](false)
+					break
+				} else if input == "var" || input == "exit" {
+					break
+				} else if input == "default" {
 					(*keep_ep_nums) = default_ken
-				default:
-					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
-					continue
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'exit', or 'default'")
 				}
 			}
 		}
@@ -95,15 +96,13 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					(*starting_ep_num) = some[int](int_input)
 					break
 				}
-
-				switch input {
-				case "default":
+				if input == "default" {
 					(*starting_ep_num) = default_sen
-				case "var", "exit":
 					break
-				default:
-					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
-					continue
+				} else if input == "var" || input == "exit" {
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter '<int>', 'var', 'exit', or 'default'")
 				}
 			}
 		}
@@ -115,18 +114,19 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 			if scanner.Scan() {
 				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
 
-				switch input {
-				case "y", "yes":
+				if input == "y" || input == "yes" {
 					(*has_season_0) = some[bool](true)
-				case "n", "no":
-					(*has_season_0) = some[bool](false)
-				case "var", "exit":
 					break
-				case "default":
+				} else if input == "n" || input == "no" {
+					(*has_season_0) = some[bool](false)
+					break
+				} else if input == "var" || input == "exit" {
+					break
+				} else if input == "default" {
 					(*has_season_0) = default_s0
-				default:
-					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
-					continue
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'exit', or 'default'")
 				}
 			}
 		}
@@ -146,7 +146,6 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					break
 				} else {
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'default', 'exit', or a valid naming scheme\ninput:", input, "\nerror:", err)
-					continue
 				}
 			}
 		}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -56,6 +56,7 @@ func prompt_additional_options(options AdditionalOptions, path string) (Addition
 	default_ken := some[bool](false)
 	default_sen := some[int](1)
 	default_s0 := some[bool](false)
+	default_ns := some[string]("default")
 
 	// prompt user for additional options
 	if options.keep_ep_nums.is_none() {
@@ -135,7 +136,8 @@ func prompt_additional_options(options AdditionalOptions, path string) (Addition
 			}
 		}
 	}
-	if options.naming_scheme.is_none() {
+	naming_scheme, _ := options.naming_scheme.get()
+	if options.naming_scheme.is_none() || naming_scheme != "default" {
 		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\ninputs: (<naming scheme>/var/default)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
@@ -143,8 +145,10 @@ func prompt_additional_options(options AdditionalOptions, path string) (Addition
 				input := scanner.Text()
 				input = strings.TrimSpace(input)
 
-				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" {
+				if strings.ToLower(input) == "var" {
 					break
+				} else if input == "default" {
+					options.naming_scheme = default_ns
 				} else if input == "exit" {
 					return options
 				} else if err := validate_naming_scheme(input); err == nil {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -57,7 +57,7 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Option[int], has_season_0 *Option[bool], naming_scheme *Option[string], path string) {
 	// prompt user for additional options
 	if (*keep_ep_nums).is_none() {
-		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\ninputs: (y/n/var/default/exit)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {
@@ -78,7 +78,7 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 		}
 	}
 	if (*starting_ep_num).is_none() {
-		fmt.Println("[INPUT]\nstarting episode number for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<int>/var/default/exit)")
+		fmt.Println("[INPUT]\nstarting episode number for", filepath.Base(path), "?\ninputs: (<int>/var/default/exit)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {
@@ -101,7 +101,7 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 		}
 	}
 	if (*has_season_0).is_none() {
-		fmt.Println("[INPUT]\nis the specials/extras directory under", filepath.Base(path), "season 0?\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		fmt.Println("[INPUT]\nspecials/extras directory under", filepath.Base(path), "as season 0?", "\ninputs: (y/n/var/default/exit)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {
@@ -122,7 +122,7 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 		}
 	}
 	if (*naming_scheme).is_none() {
-		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<naming scheme>/var/default)")
+		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\ninputs: (<naming scheme>/var/default)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -1,24 +1,17 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool], naming_scheme Option[string]) (SeriesInfo, error) {
 	// get prerequsite info for renaming series
-	info := SeriesInfo{
-		path: 				path,
-		series_type: 		s_type,
-		seasons: 			make(map[int]string),
-		movies: 			make([]string, 0),
-		keep_ep_nums: 		keep_ep_nums,
-		starting_ep_num: 	starting_ep_num,
-	}
-
 	is_valid_type := map[string]bool{
 		"single_season_no_movies": true,
 		"single_season_with_movies": true,
@@ -29,11 +22,24 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 	if !is_valid_type[s_type] {
 		return SeriesInfo{}, fmt.Errorf("unknown series type: %s", s_type)
 	}
+
+	// if additional options are none aka user inputted var, ask for user input
+	prompt_additional_options(&keep_ep_nums, &starting_ep_num, &has_season_0, &naming_scheme, path)
+	info := SeriesInfo{
+		path: 				path,
+		series_type: 		s_type,
+		seasons: 			make(map[int]string),
+		movies: 			make([]string, 0),
+		keep_ep_nums: 		keep_ep_nums,
+		starting_ep_num: 	starting_ep_num,
+		naming_scheme: 		naming_scheme,
+	}
+
 	s0, err := has_season_0.get()
 	if err != nil {
 		return SeriesInfo{}, err
 	}
-	seasons, movies, err := get_series_content(path, s_type, s0)
+	seasons, movies, err := fetch_series_content(path, s_type, s0)
 	if err != nil {
 		return SeriesInfo{}, err
 	}
@@ -48,7 +54,96 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 	return info, nil
 }
 
-func get_series_content (path string, s_type string, has_season_0 bool) (map[int]string, []string, error) {
+func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Option[int], has_season_0 *Option[bool], naming_scheme *Option[string], path string) {
+	// prompt user for additional options
+	if (*keep_ep_nums).is_none() {
+		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+				switch input {
+				case "y", "yes":
+					(*keep_ep_nums) = some[bool](true)
+				case "n", "no":
+					(*keep_ep_nums) = some[bool](false)
+				case "var", "default":
+					break
+				default:
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
+					continue
+				}
+			}
+		}
+	}
+	if (*starting_ep_num).is_none() {
+		fmt.Println("[INPUT]\nstarting episode number for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<int>/var/default/exit)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+				int_input, err := strconv.Atoi(input)
+				if err == nil {
+					(*starting_ep_num) = some[int](int_input)
+					break
+				}
+
+				switch input {
+				case "var", "default", "exit":
+					break
+				default:
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
+					continue
+				}
+			}
+		}
+	}
+	if (*has_season_0).is_none() {
+		fmt.Println("[INPUT]\nis the specials/extras directory under", filepath.Base(path), "season 0?\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+				switch input {
+				case "y", "yes":
+					(*has_season_0) = some[bool](true)
+				case "n", "no":
+					(*has_season_0) = some[bool](false)
+				case "var", "default", "exit":
+					break
+				default:
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
+					continue
+				}
+			}
+		}
+	}
+	if (*naming_scheme).is_none() {
+		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<naming scheme>/var/default)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := scanner.Text()
+				input = strings.TrimSpace(input)
+
+				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" || strings.ToLower(input) == "exit" {
+					break
+				} else if err := validate_naming_scheme(input); err == nil {
+					(*naming_scheme) = some[string](input)
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'default', 'exit', or a valid naming scheme\ninput:", input, "\nerror:", err)
+					continue
+				}
+			}
+		}
+	}
+}
+
+func fetch_series_content(path string, s_type string, has_season_0 bool) (map[int]string, []string, error) {
 	seasons := make(map[int]string)
 	movies := make([]string, 0)
 	
@@ -128,7 +223,7 @@ func get_series_content (path string, s_type string, has_season_0 bool) (map[int
 	return seasons, movies, nil
 }
 
-func movie_rename_prereqs (path string, m_type string) (MovieInfo, error) {
+func movie_rename_prereqs(path string, m_type string) (MovieInfo, error) {
 	info := MovieInfo{
 		path: 			path,
 		movie_type: 	m_type,

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -73,8 +73,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				} else if input == "n" || input == "no" {
 					(*keep_ep_nums) = some[bool](false)
 					break
-				} else if input == "var" || input == "exit" {
+				} else if input == "var" {
 					break
+				} else if input == "exit" {
+					return
 				} else if input == "default" {
 					(*keep_ep_nums) = default_ken
 					break
@@ -99,8 +101,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				if input == "default" {
 					(*starting_ep_num) = default_sen
 					break
-				} else if input == "var" || input == "exit" {
+				} else if input == "var" {
 					break
+				} else if input == "exit" {
+					return
 				} else {
 					fmt.Println("[ERROR]\ninvalid input, please enter '<int>', 'var', 'exit', or 'default'")
 				}
@@ -120,8 +124,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				} else if input == "n" || input == "no" {
 					(*has_season_0) = some[bool](false)
 					break
-				} else if input == "var" || input == "exit" {
+				} else if input == "var" {
 					break
+				} else if input == "exit" {
+					return					
 				} else if input == "default" {
 					(*has_season_0) = default_s0
 					break
@@ -139,8 +145,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				input := scanner.Text()
 				input = strings.TrimSpace(input)
 
-				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" || strings.ToLower(input) == "exit" {
+				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" {
 					break
+				} else if input == "exit" {
+					return
 				} else if err := validate_naming_scheme(input); err == nil {
 					(*naming_scheme) = some[string](input)
 					break

--- a/utils.go
+++ b/utils.go
@@ -169,7 +169,7 @@ func clean_title (title string) string {
 	return title
 }
 
-func split_regex_by_pipe (s string) []string {
+func split_regex_by_pipe(s string) []string {
 	var parts []string
 	depth := 0
 	part_start := 0
@@ -211,9 +211,9 @@ func has_only_one_match_group (s string) bool {
 
 func parent_token_to_int(s string) (int, error) {
 	// lmao https://regex-vis.com/?r=%3Cparent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd+%5Cs*%2C%5Cs*%5Cd+%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
-	long_form := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d \s*,\s*\d )|('[^']*')))?\s*>`)
+	long_form := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?\s*>`)
 	// lul https://regex-vis.com/?r=%3Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%5Cs*%2C%5Cs*%5Cd%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
-	short_form := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d\s*,\s*\d)|('[^']*')))?\s*>`)
+	short_form := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?\s*>`)
 	
 	if long_form.MatchString(s) {
 		return strings.Count(s, "parent"), nil

--- a/utils.go
+++ b/utils.go
@@ -220,7 +220,7 @@ func parent_token_to_int(s string) (int, error) {
 		
 	} else if short_form.MatchString(s) {
 		// only p
-		single_p := regexp.MustCompile(`p\s*:`)
+		single_p := regexp.MustCompile(`p\s*[^-]:?`)
 		if single_p.MatchString(s) {
 			return 1, nil
 		}


### PR DESCRIPTION
closes #12 

### new
1. prompt the user to input additional options if none was inputted during the initial input when executing gorn:
    1. executing gorn: **for all series**
    2. fetching entries: **per series type**
    3. renaming prereqs: **per series entry**
    4. renaming: **per season**

2. Optional fields in `Args` and `SeriesInfo` are now condensed into `AdditionalOptions`. add future options for cli here
3. `--options | -o` flag takes in either `var` or `default` where `var` assigns `var` to all additional options. `default` assigns the default values
    - default input if no `var` or `default` follows `--options` is `var`

### changes
1. range for naming series apis can now be one digit for a single character. used to be `0,0` to get the first character; now `0` is valid
2. renaming is based on full paths now. used to be based on `base_name` concatenated to `season_path`
5. all optional args are assigned default values by default (if none was inputted). used to all be none, which led to prompting user on each series type, series entry, and season