### PR TITLE
Release/ver 0.3.0: naming schemes, prompt for optional flags if var is selected, readme overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test_files
+gorn.exe

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 saltkid
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -219,274 +219,31 @@ Current APIs are:
     - additional options are the same as well except for `<p-number>`. self has no short form
 
 ___
-below are guides on how to structure directories based on media type. provided also are the default naming schemes with a sample output. 
+# Root Directory Structure Overview
 
-# Series / TV Shows
-Series contain episodes which may be under a season. The filename of an episode number can be the ff:
-1. `S01E01`, `S01 E01`, `S1E1`, `S100 E100`, `S01.E01`, `S01_E04`,  - *default for episodes*
-2. `[0x1]`, `[00x11]` - *default for movies/specials in a series*
-3. `Season 1 Episode 1`, `Season 1 Ep 1`
-4. `EP08`, `E09`
-5. your own custom naming scheme
-    - `S<season_num>E<episode_num> - <parent-parent> <parent> something static`
-    - output:
-    - `S01E01 - Fruits Basket Season 1 something static`
-    - `S01E02 - Fruits Basket Season 1 something static`
+Root directories should contain series roots and/or movie roots (let's call these subroots). Each subroot should contain series and movie entries respectively.`
 
-## current valid directory structures
-### 1. single season no movie/s
-directory input
+sample root directory
 ```
-<series root dir>
-|__ <series name>
-    |__ filename.mkv
-    |__ filename2.mkv
-    |__ ...
-    |__ some other filename.mkv
-```
-sample output
-```
-Series
-|__ Nichijou
-    |__ S01E01 Nichijou.mkv
-    |__ S01E02 Nichijou.mkv
-    |__ ...
-    |__ S01EXX Nichijou.mkv
-```
-default formatting
-```
-S<season_num>E<episode_num> <parent>
-```
-
-### 2. single season with movie/s
-directory input
-```
-<series root dir>
-|__ <series name>
-    |__ <series name>
-    |   |__ filename.mkv
-    |   |__ filename2.mkv
-    |   |__ ...
-    |   |__ some other filename.mkv
-    |
-    |__ <movie name>
-        |__ some filename.mkv
-```
-sample output
-```
-Series
-|__ Neon Genesis Evangelion
-    |__ Neon Genesis Evangelion
-    |   |__ S01E01 Neon Genesis Evangelion.mkv
-    |   |__ S01E02 Neon Genesis Evangelion.mkv
-    |   |__ ...
-    |   |__ S01EXX Neon Genesis Evangelion.mkv
-    |
-    |__ The End of Evangelion
-        |__ Neon Genesis Evangelion The End of Evangelion [1x27].mkv
-```
-default formatting
-```
-episodes: S<season_num>E<episode_num> <parent>
-movies: <parent-parent> <parent>
-```
-* note: `[1x27]` needs to be added manually since this **gorn** does not scrape data off tmdb/tvdb. 
-
-### 3. multiple season no movie/s
-directory input
-```
-<series root dir>
-|__ <series name>
-    |__ <season name>
-    |   |__ filename.mkv
-    |   |__ filename2.mkv
-    |   |__ ...
-    |   |__ some other filename.mkv
-    |
-    |__ <season name>
-        |__ filename.mkv
-        |__ filename2.mkv
+<root dir>
+|__ <series subroot>
+|   |__ <series entry>
+|   |   |__ ...
+|   |
+|   |__ <series entry>
+|       |__ ...
+|
+|__ <movie subroot>
+|   |__ <movie entry>
+|   |   |__ ...
+|   |
+|   |__ <movie entry>
+|       |__ ...
+|
+|__ <movie subroot>
+    |__ <movie entry>
         |__ ...
-        |__ some other filename.mkv
+```
+*where `...` may mean media files or subdirectories like extras, specials, subs, etc*
 
-```
-sample output
-```
-Series
-|__ Mob Psycho 100
-    |__ Season 1
-    |   |__ S01E01 Mob Psycho 100.mkv
-    |   |__ S01E02 Mob Psycho 100.mkv
-    |   |__ ...
-    |   |__ S01EXX Mob Psycho 100.mkv
-    |
-    |__ Season 2
-        |__ S02E01 Mob Psycho 100.mkv
-        |__ S02E02 Mob Psycho 100.mkv
-        |__ ...
-        |__ S02EXX Mob Psycho 100.mkv
-```
-default formatting
-```
-episodes: S<season_num>E<episode_num> <parent-parent>
-movies: <parent-parent> <parent>
-```
-### 4. multiple season with movie/s
-directory input
-```
-<series root dir>
-|__ <series name>
-    |__ <special name>
-    |   |__ filename.mkv
-    |
-    |__ <season name>
-    |   |__ filename.mkv
-    |   |__ filename2.mkv
-    |   |__ ...
-    |   |__ some other filename.mkv
-    |
-    |__ <season name>
-        |__ filename.mkv
-        |__ filename2.mkv
-        |__ ...
-        |__ some other filename.mkv
-
-```
-sample output
-```
-Series
-|__ Fruits Basket
-    |__ Prelude
-    |   |__ Fruits Basket Prelude [0x1]
-    |
-    |__ Season 1
-    |   |__ S01E01 Fruits Basket.mkv
-    |   |__ S01E02 Fruits Basket.mkv
-    |   |__ ...
-    |   |__ S01EXX Fruits Basket.mkv
-    |
-    |__ Season 2
-        |__ S02E01 Fruits Basket.mkv
-        |__ S02E02 Fruits Basket.mkv
-        |__ ...
-        |__ S02EXX Fruits Basket.mkv
-```
-default formatting
-```
-episodes: S<season_num>E<episode_num> <parent-parent>
-movies: <parent-parent> <parent>
-```
-* note: `[0x1]` needs to be added manually since this **gorn** does not scrape data off tmdb/tvdb.
-### 5. named seasons with or without movies
-* note: the `01. title` before the season name is important to determine order
-    * `.` after digits can be `-` or `_`, and can be separated by spaces: `02 - title` `03__title`
-
-directory input
-```
-<series root dir>
-|__ <series name>
-    |__ 01. <season name>
-    |   |__ filename.mkv
-    |   |__ filename2.mkv
-    |   |__ ...
-    |   |__ some other filename.mkv
-    |
-    |__ 02. <season name>
-        |__ filename.mkv
-        |__ filename2.mkv
-        |__ ...
-        |__ some other filename.mkv
-
-```
-sample output
-```
-Series
-|__ JoJos Bizzare Adventure
-    |__ 01. Phantom Blood
-    |   |__ S01E01 JoJos Bizzare Adventure Phantom Blood.mkv
-    |   |__ S01E02 JoJos Bizzare Adventure Phantom Blood.mkv
-    |   |__ ...
-    |   |__ S01EXX JoJos Bizzare Adventure Phantom Blood.mkv
-    |
-    |__ 01. Battle Tendency
-    |   |__ S02E01 JoJos Bizzare Adventure Battle Tendency.mkv
-    |   |__ S02E02 JoJos Bizzare Adventure Battle Tendency.mkv
-    |   |__ ...
-    |   |__ S02EXX JoJos Bizzare Adventure Battle Tendency.mkv
-    |
-    |__ 02. Stardust Crusaders
-        |__ S03E01 JoJos Bizzare Adventure Stardust Crusaders.mkv
-        |__ S03E02 JoJos Bizzare Adventure Stardust Crusaders.mkv
-        |__ ...
-        |__ S03EXX JoJos Bizzare Adventure Stardust Crusaders.mkv
-```
-default formatting
-```
-episodes: S<season_num>E<episode_num> <parent-parent> <parent>
-movies: <parent-parent> <parent>
-```
-
-# Movies
-Movies contain a movie file which may be under a movie set. The filename of a movie can be the ff
-
-1. name of `parent_dir` which is most likely the title of the movie - *default for both standalone and movie sets*
-2. your own custom naming scheme *(which may or may not be based on your parent directories)*
-    - `<parent-parent> - <parent> something static`
-    - `Rebuild of Evangelion - Evangelion 1.0 You are (Not) Alone something static`
-    - `Rebuild of Evangelion - Evangelion 2.0 You can (Not) Advance something static`
-
-## current valid directory structures
-### 1. standalone movies
-directory input
-```
-<movies root dir>
-|__ <movie name>
-    |__ filename.mkv
-```
-sample output
-```
-Movies
-|__ Akira
-    |__ Akira.mkv
-```
-default formatting
-```
-<parent>
-```
-
-### 2. movie sets
-directory input
-```
-<movies root dir>
-|__ <movie set name>
-    |__ <movie name>
-    |   |__ filename.mkv
-    |
-    |__ <movie name>
-    |   |__ filename.mkv
-    |
-    |__ ...
-    |
-    |__ <movie name>
-        |__ filename.mkv
-```
-sample output
-```
-Movies
-|__ Rebuild of Evangelion
-    |__ Evangelion 1.0 - You Are (Not) Alone
-    |   |__ Evangelion 1.0 - You Are (Not) Alone.mkv
-    |
-    |__ Evangelion 2.0 - You Can (Not) Advance
-    |   |__ Evangelion 2.0 - You Can (Not) Advance.mkv
-    |
-    |__ Evangelion 3.0 You Can (Not) Redo
-    |   |__ Evangelion 3.0 You Can (Not) Redo.mkv
-    |
-    |__ Evangelion 3.0+1.0 Thrice Upon a Time
-        |__ Evangelion 3.0+1.0 Thrice Upon a Time.mkv
-```
-default formatting
-```
-<parent>
-```
+For more information about Subroot (series/movies) Directory Structures, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
 ### current progress (to v1.0): see [this issue](https://github.com/saltkid/gorn/issues/1)
+___
+1. [Overview](#overview)
+2. [Prerequisites](#prerequisites)
+3. [Usage](#usage)
+    1. [Optional Flags](#optional-flags)
 ___ 
 # Overview
 Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.
@@ -96,3 +101,5 @@ For more information, see [this wiki page](https://github.com/saltkid/gorn/wiki/
 ___
 
 Credits: [@saltkid](https://github.com/saltkid)
+
+License: MIT License

--- a/README.md
+++ b/README.md
@@ -63,55 +63,105 @@ gorn --series path/to/series/root/dir --movies path/to/movies/root/dir -s path/t
 User can specify series and movie root dirs separately, can specify only one of either, and can specify any number of dirs. Other than that, it shares the same default renaming behavior as specifying a root dir
 ___
 ## Additional Options
+Some of these flags have default values if they are not specified.
+This is different from the default value if a flag is specified but without a value.
+
+- if `--keep-ep-nums` is not specified, it still has a default value (`all default`).
+- if `--naming-scheme` is specified without a value, it will have a default value (`all yes`).
+
 ### 1. --help
+- **short form:** `-h`
+- **values:** `<other flags>`
+- **default:** none
+
 Shows the simple help message. If user inputted a flag right after `--help`, it will show the detailed help message for that specific flag.
 
 `-h` is the short form
 
 Example: `gorn -h --naming-scheme`, `gorn --help --help`
 ### 2. --version
+- **short form:** `-v`
+- **values:** none
+- **default:** none
+
 Shows the welcome message along with the version.
 
 `-v` is the short form
 
 Example: `gorn -v`, `gorn --version`
-### 1. --keep-ep-num
+
+### 3. --options
+- **short form:** `-o`
+- **values:** none
+- **default:** none
+
+By default, **gorn** will populate flags 4-7 below with default values. This is on an *all media level*.
+
+`--options` flag will ensure the flags are not populated. Since there will be no values, the user will be prompted to input them either during:
+- *per series type level*
+- *per series entry level* (if no input on per series type level)
+
+`-o` is the short form
+
+### 4. --keep-ep-num
+- **short form:** `-ken`
+- **values:** `all yes/no/default | var`
+- **default if ommitted:** `all default`
+- **default if no value:** `all yes`
+
 By default, episode numbers are padded to 2 digits and will start at 01. These are automatically generated and renames the files based on natural sorting.
 
-`--keep-ep-nums all no` is the default behavior if the flag is not present.
+If this flag is set to `all yes`, **gorn** will keep the original episode numbers in the filename based on common naming patterns. If none was found in the filename, it will not rename for that specific file.
 
-If `--keep-ep-nums` flag is present or user inputted `--keep-ep-nums all yes`, gorn will keep the original episode numbers in the filename based on common naming patterns.
+This can be useful if you only have episodes that are canon, aka you don't have filler episodes, so you want to keep the episode number already in the filename.
 
-if none was found in the filename, it will not rename for that specific file. This can be useful if you only have episodes that are canon, aka you don't have filler episodes, so you want to keep the episode number already in the filename.
+If this flag is set to `var`, **gorn** will ask for user input whether or not to keep the episode numbers again:
+- *per series type level*
+- *per series entry level*
 
-If user inputted `--keep-ep-nums var`, gorn will ask for user input whether or not to keep the episode numbers again for each series entry.
+### 5. --starting-ep-num
+- **short form:** `-sen`
+- **values:** `all <num>/default | var`
+- **default if ommitted:** `all default`
+- **default if no value:** `all 1`
 
-`-ken` is the short form
-
-### 2. --starting-ep-num
 By default, episode numbers are padded to 2 digits and will start at 01. You can specify a different starting number to start at by `--starting-ep-num all <num>`.
 
-If user inputted `--starting-ep-num var`, gorn will ask for user input again on what starting episode number to start at for each series entry.
+If this flag is set to `var`, **gorn** will ask for user input again on what starting episode number to start at:
+- *per series type level*
+- *per series entry level*
 
-`-sen` is the short form
+### 6. --has-season-0
+- **short form:** `-s0`
+- **values:** `all yes/no/default | var`
+- **default if ommitted:** `all default`
+- **default if no value:** `all yes`
 
-### 3. --has-season-0
-By default, the media files in specials/extras directory under a series entry are not renamed. `--has-season-0 all no` is the default behavior if the flag is not present. This will ignore the specials/extras directory.
+By default, the media files in specials/extras directory under a series entry will be ignored and are not renamed.
 
-If the flag `--has-season-0` or user inputted `--has-season-0 all yes`, gorn will rename the files in the specials/extras directory under a series entry, treating it as the *season 0* of the series entry.
+If the flag is set to `all yes`, **gorn** will rename the files in the specials/extras directory under a series entry, treating it as the *season 0* of the series entry.
 
-*Note that there must be ***ONE*** special/extras directory under the series entry. If there are multiple, it won't rename the files and inform the user.*
+*Note that if the flag is set to `all yes`, there must be ***ONE*** special/extras directory under the series entry. If there are multiple, it won't rename the files and inform the user.*
 
-If user inputted `--has-season-0 var`, gorn will ask for user input again on whether or not to rename the files in the specials/extras directory as season 0 under a series entry.
+*if the flag is set to `all no`, there can be any number of specials/extras directories*
 
-`-s0` is the short form
+If this flag is set to `var`, **gorn** will ask for user input again on whether or not to rename the files in the specials/extras directory as season 0 under a series entry:
+- *per series type level*
+- *per series entry level*
 
-### 4. --naming-scheme
-By default, gorn will rename the files differently based on the type of media. User can override this by `--naming-scheme all "<scheme>"` or `--naming-scheme var`.
+### 7. --naming-scheme
+- **short form:** `-ns`
+- **values:** `all "<scheme>"/default | var`
+- **default if ommitted:** `all default`
+- **default if no value:** none
+
+By default, **gorn** will rename the files differently based on the type of media. User can override this by `--naming-scheme all "<scheme>"` or `--naming-scheme var`.
 
 `all "<scheme>"` overrides the naming scheme for all media files regardless of type (series only; movies will ignore these additional options)
 
-`-ns` is the short form
+If the flag is set to `var`, **gorn** will ask for user input again on the naming scheme:
+- *per series type level*
+- *per series entry level*
 
 ### *scheme*
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ ___
 3. [Usage](#usage)
     1. [Optional Flags](#optional-flags)
 ___ 
-# Overview
+# [Overview](https://github.com/saltkid/gorn/wiki)
 Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.
 
-# Prerequisites
+# [Prerequisites](https://github.com/saltkid/gorn/wiki/Directory-Structure)
 Have at least one of any of these directories:
 1. **root directory containing series roots and/or movie roots (subroots)**
 ```
@@ -51,7 +51,7 @@ where ... may mean media files or subdirectories (like extras, specials, subs, e
 ```
 For a more detailed explanation of recommended directory structures, different series/movie types depending on structure, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)
 ___
-# Usage
+# [Usage](https://github.com/saltkid/gorn/wiki/Usage)
 To renames all series and movies in the root directory based on directory naming and structure:
 ```
 gorn --root path/to/root/dir
@@ -73,7 +73,7 @@ gorn --movies path/to/movies/subroot/dir
 gorn -r path/to/root/dir -s path/to/another/series/subroot/dir -m path/to/another/movies/subroot/dir
 ```
 ___
-## Optional Flags
+## [Optional Flags](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
 These are the additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
 1. `--help | -h`
     - **values:** `<other flags>`
@@ -90,7 +90,7 @@ These are the additional options that can be passed to the cli. For a more detai
 7. `--naming-scheme | -ns`
     - **values:** `all "<scheme>"/default` or `var`
 
-### *scheme*
+### [*scheme*](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)
 scheme can be composed of any character (as long as its a valid filename) and/or APIs enclosed in <> like:
 - `S<season_num>E<episode_num>`
     - *output*: `S01E01`

--- a/README.md
+++ b/README.md
@@ -4,9 +4,8 @@ ___
 Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.
 
 # Prerequisites
-A directory to pass to the cli.
-have any number of these (any combination of these will work too):
-- a root directory containing series directories and/or movie directories
+Have any number of these directories:
+1. **root directory containing series roots and/or movie roots (subroots)**
 ```
 <root dir>
 |__ <series root dir 1>
@@ -25,7 +24,9 @@ have any number of these (any combination of these will work too):
 
 where ... may mean media files or subdirectories (like extras, specials, subs, etc)
 ```
-- a series root directory containing series entries
+*Note that there can be multiple series/movie subroots in the same root directory.*
+
+2. **series subroot directory containing series entries**
 ```
 <series root dir 1>
 |__ <series entry 1>
@@ -34,7 +35,7 @@ where ... may mean media files or subdirectories (like extras, specials, subs, e
 |__ <series entry 2>
     |__ ...
 ```
-- or a movie root directory containing movie entries
+3. **movie subroot directory containing movie entries**
 ```
 <movie root dir 1>
     |__ <movie entry 1>
@@ -43,6 +44,7 @@ where ... may mean media files or subdirectories (like extras, specials, subs, e
     |__ <movie entry 2>
         |__ ...
 ```
+For a more detailed explanation of recommended directory structures, different series/movie types depending on structure, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)
 ___
 # Usage
 To renames all series and movies in the root directory based on directory naming and structure:
@@ -92,33 +94,5 @@ scheme can be composed of any character (as long as its a valid filename) and/or
 
 For more information, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)
 ___
-# Root Directory Structure Overview
 
-Root directories should contain series roots and/or movie roots (let's call these subroots). Each subroot should contain series and movie entries respectively.
-
-sample root directory
-```
-<root dir>
-|__ <series subroot>
-|   |__ <series entry>
-|   |   |__ ...
-|   |
-|   |__ <series entry>
-|       |__ ...
-|
-|__ <movie subroot>
-|   |__ <movie entry>
-|   |   |__ ...
-|   |
-|   |__ <movie entry>
-|       |__ ...
-|
-|__ <movie subroot>
-    |__ <movie entry>
-        |__ ...
-```
-*where `...` may mean media files or subdirectories like extras, specials, subs, etc*
-
-Note that there can be multiple series/movie subroots in the same root directory.
-
-For more information about Subroot (series/movies) Directory Structures, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)
+Credits: [@saltkid](https://github.com/saltkid)

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Current APIs are:
 ___
 # Root Directory Structure Overview
 
-Root directories should contain series roots and/or movie roots (let's call these subroots). Each subroot should contain series and movie entries respectively.`
+Root directories should contain series roots and/or movie roots (let's call these subroots). Each subroot should contain series and movie entries respectively.
 
 sample root directory
 ```
@@ -245,5 +245,7 @@ sample root directory
         |__ ...
 ```
 *where `...` may mean media files or subdirectories like extras, specials, subs, etc*
+
+Note that there can be multiple series/movie subroots in the same root directory.
 
 For more information about Subroot (series/movies) Directory Structures, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ ___
 Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.
 
 # Prerequisites
-You would need to have a directory to pass to the cli.
-have any of these (multiple of these of any combination will work too):
+A directory to pass to the cli.
+have any number of these (any combination of these will work too):
 - a root directory containing series directories and/or movie directories
 ```
 <root dir>
@@ -48,7 +48,7 @@ where ... may mean media files or subdirectories (like extras, specials, subs, e
 ```
 gorn --root path/to/root/dir
 ```
-This would rename all series and movies in the root directory based on directory naming and structure. The episode numbers per entry/season/part will be padded to 2 digits and will start at 01. movies will be named based on the directory they are in. naming scheme will vary depending on the type of media:
+Renames all series and movies in the root directory based on directory naming and structure. The episode numbers per entry/season/part will be padded to 2 digits and will start at 01. movies will be named based on the directory they are in. naming scheme will vary depending on the type of media which gorn will detect:
 - standalone movie, movie set
 - single season, multiple seasons, and named parts/seasons. all with or without movies
 
@@ -63,12 +63,26 @@ gorn --series path/to/series/root/dir --movies path/to/movies/root/dir -s path/t
 User can specify series and movie root dirs separately, can specify only one of either, and can specify any number of dirs. Other than that, it shares the same default renaming behavior as specifying a root dir
 ___
 ## Additional Options
+### 1. --help
+Shows the simple help message. If user inputted a flag right after `--help`, it will show the detailed help message for that specific flag.
+
+`-h` is the short form
+
+Example: `gorn -h --naming-scheme`, `gorn --help --help`
+### 2. --version
+Shows the welcome message along with the version.
+
+`-v` is the short form
+
+Example: `gorn -v`, `gorn --version`
 ### 1. --keep-ep-num
 By default, episode numbers are padded to 2 digits and will start at 01. These are automatically generated and renames the files based on natural sorting.
 
 `--keep-ep-nums all no` is the default behavior if the flag is not present.
 
-If `--keep-ep-nums` flag is present or user inputted `--keep-ep-nums all yes`, gorn will keep the original episode numbers in the filename based on common naming patterns. if none was found in the filename, it will not rename for that specific file. This can be useful if you only have episodes that are canon, aka you don't have filler episodes, so you want to keep the episode number already in the filename.
+If `--keep-ep-nums` flag is present or user inputted `--keep-ep-nums all yes`, gorn will keep the original episode numbers in the filename based on common naming patterns.
+
+if none was found in the filename, it will not rename for that specific file. This can be useful if you only have episodes that are canon, aka you don't have filler episodes, so you want to keep the episode number already in the filename.
 
 If user inputted `--keep-ep-nums var`, gorn will ask for user input whether or not to keep the episode numbers again for each series entry.
 
@@ -101,7 +115,7 @@ By default, gorn will rename the files differently based on the type of media. U
 
 ### *scheme*
 
-scheme is the naming scheme. It's composed of any character and/or APIs enclosed in <> like:
+scheme can be composed of any character (as long as its a valid filename) and/or APIs enclosed in <> like:
 - `S<season_num>E<episode_num>`
     - *output*: `S01E01`
 - `S<season_num>E<episode_num> - <parent-parent> <parent> static text` 
@@ -123,16 +137,20 @@ Current APIs are:
 3. `<parent>`
     - represents the parent directory of the media file. if no option was specified, it will copy the whole name of the parent directory
 
-    - additional option for parent is to select the range of characters from the parent directory name. it can be a range of two numbers like `<parent: 0,4>` or a regex expression enclosed in single quotes like `<parent: 'S(\d+)'>`
-        - `<parent: 0,3>` which will copy the first 4 characters of the parent directory name
+    - additional option for parent is to select the range of characters from the parent directory name
+    - it can be:
+        - a range of two numbers like `<parent: 0,3>`
+            - `<parent: 0,3>` which will copy the first 4 characters of the parent directory name
+        - a single number like `<parent: 4>`
+            - `<parent: 4>` which will copy the 5th character of the parent directory name
+        - a regex expression enclosed in single quotes like `<parent: 'S(\d+)'>`
+            - `<parent: 'S(\d+)'>` which will copy the capture group `(\d+)` that is prepended by `S` from the parent directory name. Notes:
+                1. it can only have one capture group per part
+                2. each part is separated by `|`
+                3. ie. `S(\d+)|E(\d+)` is valid. It has one capture group per part and has 2 parts
+                4. ie. `S(E|\d+)` has one capture group and one part. `|` inside parenthesis does not count as a part separator. only `|` outside parenthesis is part separator
+                5. ie. `'S(E)(\d+)|S(\d+)` is invalid since the first part has 2 capture groups, even if the second part has only 1
 
-        - `<parent: 'S(\d+)'>` which will copy the capture group `(\d+)` that is prepended by `S` from the parent directory name. Notes:
-            - it can only have one capture group per part
-
-            - each part is separated by `|`
-            - ie. `S(\d+)|E(\d+)` is valid. It has one capture group per part and has 2 parts
-            - ie. `S(E|\d+)` has one capture group and one part. `|` inside parenthesis does not count as a part separator. only `|` outside parenthesis is part separator
-            - ie. `'S(E)(\d+)|S(\d+)` is invalid since the first part has 2 capture groups, even if the second part has only 1
     - another additional option is going above just the parent of the current directory.
         - `<parent-parent>` which will copy the parent of the parent directory
 

--- a/README.md
+++ b/README.md
@@ -43,181 +43,54 @@ where ... may mean media files or subdirectories (like extras, specials, subs, e
     |__ <movie entry 2>
         |__ ...
 ```
-
+___
 # Usage
+To renames all series and movies in the root directory based on directory naming and structure:
 ```
 gorn --root path/to/root/dir
 ```
-Renames all series and movies in the root directory based on directory naming and structure. The episode numbers per entry/season/part will be padded to 2 digits and will start at 01. movies will be named based on the directory they are in. naming scheme will vary depending on the type of media which gorn will detect:
-- standalone movie, movie set
-- single season, multiple seasons, and named parts/seasons. all with or without movies
 
+User can specify multiple root/subroot directories to rename:
 ```
 gorn -r path/to/root/dir --root path/to/another/root/dir
 ```
-User can specify multiple root directories to rename.
 
+User can specify series and movie subroot dirs separately. User can also specify multiple subroot dirs. Other than that, it shares the same default renaming behavior as specifying a root dir
 ```
-gorn --series path/to/series/root/dir --movies path/to/movies/root/dir -s path/to/another/series/root/dir -m path/to/another/movies/root/dir
+gorn --series path/to/series/subroot/dir
 ```
-User can specify series and movie root dirs separately, can specify only one of either, and can specify any number of dirs. Other than that, it shares the same default renaming behavior as specifying a root dir
+```
+gorn --movies path/to/movies/subroot/dir
+```
+```
+gorn -r path/to/root/dir -s path/to/another/series/subroot/dir -m path/to/another/movies/subroot/dir
+```
 ___
-## Additional Options
-Some of these flags have default values if they are not specified.
-This is different from the default value if a flag is specified but without a value.
-
-- if `--keep-ep-nums` is not specified, it still has a default value (`all default`).
-- if `--naming-scheme` is specified without a value, it will have a default value (`all yes`).
-
-### 1. --help
-- **short form:** `-h`
-- **values:** `<other flags>`
-- **default:** none
-
-Shows the simple help message. If user inputted a flag right after `--help`, it will show the detailed help message for that specific flag.
-
-`-h` is the short form
-
-Example: `gorn -h --naming-scheme`, `gorn --help --help`
-### 2. --version
-- **short form:** `-v`
-- **values:** none
-- **default:** none
-
-Shows the welcome message along with the version.
-
-`-v` is the short form
-
-Example: `gorn -v`, `gorn --version`
-
-### 3. --options
-- **short form:** `-o`
-- **values:** none
-- **default:** none
-
-By default, **gorn** will populate flags 4-7 below with default values. This is on an *all media level*.
-
-`--options` flag will ensure the flags are not populated. Since there will be no values, the user will be prompted to input them either during:
-- *per series type level*
-- *per series entry level* (if no input on per series type level)
-
-`-o` is the short form
-
-### 4. --keep-ep-num
-- **short form:** `-ken`
-- **values:** `all yes/no/default | var`
-- **default if ommitted:** `all default`
-- **default if no value:** `all yes`
-
-By default, episode numbers are padded to 2 digits and will start at 01. These are automatically generated and renames the files based on natural sorting.
-
-If this flag is set to `all yes`, **gorn** will keep the original episode numbers in the filename based on common naming patterns. If none was found in the filename, it will not rename for that specific file.
-
-This can be useful if you only have episodes that are canon, aka you don't have filler episodes, so you want to keep the episode number already in the filename.
-
-If this flag is set to `var`, **gorn** will ask for user input whether or not to keep the episode numbers again:
-- *per series type level*
-- *per series entry level*
-
-### 5. --starting-ep-num
-- **short form:** `-sen`
-- **values:** `all <num>/default | var`
-- **default if ommitted:** `all default`
-- **default if no value:** `all 1`
-
-By default, episode numbers are padded to 2 digits and will start at 01. You can specify a different starting number to start at by `--starting-ep-num all <num>`.
-
-If this flag is set to `var`, **gorn** will ask for user input again on what starting episode number to start at:
-- *per series type level*
-- *per series entry level*
-
-### 6. --has-season-0
-- **short form:** `-s0`
-- **values:** `all yes/no/default | var`
-- **default if ommitted:** `all default`
-- **default if no value:** `all yes`
-
-By default, the media files in specials/extras directory under a series entry will be ignored and are not renamed.
-
-If the flag is set to `all yes`, **gorn** will rename the files in the specials/extras directory under a series entry, treating it as the *season 0* of the series entry.
-
-*Note that if the flag is set to `all yes`, there must be ***ONE*** special/extras directory under the series entry. If there are multiple, it won't rename the files and inform the user.*
-
-*if the flag is set to `all no`, there can be any number of specials/extras directories*
-
-If this flag is set to `var`, **gorn** will ask for user input again on whether or not to rename the files in the specials/extras directory as season 0 under a series entry:
-- *per series type level*
-- *per series entry level*
-
-### 7. --naming-scheme
-- **short form:** `-ns`
-- **values:** `all "<scheme>"/default | var`
-- **default if ommitted:** `all default`
-- **default if no value:** none
-
-By default, **gorn** will rename the files differently based on the type of media. User can override this by `--naming-scheme all "<scheme>"` or `--naming-scheme var`.
-
-`all "<scheme>"` overrides the naming scheme for all media files regardless of type (series only; movies will ignore these additional options)
-
-If the flag is set to `var`, **gorn** will ask for user input again on the naming scheme:
-- *per series type level*
-- *per series entry level*
+## Optional Flags
+These are the additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
+1. `--help | -h`
+    - **values:** `<other flags>`
+2. `--version | -v`
+    - **values:** none
+3. `--options | -o`
+    - **values:** none
+4. `--keep-ep-num | -ken`
+    - **values:** `all yes/no/default` or `var`
+5. `--starting-ep-num | -sen`
+    - **values:** `all <num>/default` or `var`
+6. `--has-season-0 | -s0`
+    - **values:** `all yes/no/default` or `var`
+7. `--naming-scheme | -ns`
+    - **values:** `all "<scheme>"/default` or `var`
 
 ### *scheme*
-
 scheme can be composed of any character (as long as its a valid filename) and/or APIs enclosed in <> like:
 - `S<season_num>E<episode_num>`
     - *output*: `S01E01`
 - `S<season_num>E<episode_num> - <parent-parent> <parent> static text` 
     - *output*: `S01E01 - Fruits Basket Season 1 static text`
 
-## Naming Scheme APIs
-Current APIs are:
-1. `<season_num>`
-    - represents the season number which is based on series type, and directory structure and naming
-    - additional option for season num is padding with 0s
-        - `<season_num: 2>` which pads the result to 2 digits
-        - `<season_num: 3>` which pads the result to 3 digits
-        - etc ...
-
-2. `<episode_num>`
-    - represents the episode number which is either read from the filename or generated based on the `--keep-ep-nums` and `--starting-ep-num` flags
-    - additional option for episode num is padding with 0s just like `<season_num>`
-
-3. `<parent>`
-    - represents the parent directory of the media file. if no option was specified, it will copy the whole name of the parent directory
-
-    - additional option for parent is to select the range of characters from the parent directory name
-    - it can be:
-        - a range of two numbers like `<parent: 0,3>`
-            - `<parent: 0,3>` which will copy the first 4 characters of the parent directory name
-        - a single number like `<parent: 4>`
-            - `<parent: 4>` which will copy the 5th character of the parent directory name
-        - a regex expression enclosed in single quotes like `<parent: 'S(\d+)'>`
-            - `<parent: 'S(\d+)'>` which will copy the capture group `(\d+)` that is prepended by `S` from the parent directory name. Notes:
-                1. it can only have one capture group per part
-                2. each part is separated by `|`
-                3. ie. `S(\d+)|E(\d+)` is valid. It has one capture group per part and has 2 parts
-                4. ie. `S(E|\d+)` has one capture group and one part. `|` inside parenthesis does not count as a part separator. only `|` outside parenthesis is part separator
-                5. ie. `'S(E)(\d+)|S(\d+)` is invalid since the first part has 2 capture groups, even if the second part has only 1
-
-    - another additional option is going above just the parent of the current directory.
-        - `<parent-parent>` which will copy the parent of the parent directory
-
-        - `<parent-parent: 0,4>` which will copy the first 4 characters of the parent of the parent directory
-
-        - `<parent-parent-parent>` which will copy the parent of the parent of the parent directory
-
-        - `<p>`: short form. `<p>` is equivalent to `<parent>` in every way
-
-        - `<p-2>`: you can specify how much further up the directory tree you want to go by appending a number
-
-        - `<p-2>` is equivalent to `<parent-parent>` in every way
-
-4. `<self>`
-    - same as parent but instead of being based on the parent directory name, it is based on the name of the media file before renaming it
-    - additional options are the same as well except for `<p-number>`. self has no short form
-
+For more information, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)
 ___
 # Root Directory Structure Overview
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ ___
 Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.
 
 # Prerequisites
-Have any number of these directories:
+Have at least one of any of these directories:
 1. **root directory containing series roots and/or movie roots (subroots)**
 ```
 <root dir>

--- a/help.go
+++ b/help.go
@@ -1,0 +1,213 @@
+package main
+
+import "fmt"
+
+func welcome_msg(version string) {
+	fmt.Println("gorn - go rename tool")
+	fmt.Println("version:", version)
+	fmt.Println("renames series/movies media files based on directory naming and structure")
+	fmt.Println("for more usage information, run 'gorn -h'")
+	fmt.Println("https://github.com/saltkid/gorn")
+}
+
+func help(flag string) {
+	switch flag {
+	case "":
+		fmt.Println("Basic usage: gorn -r path/to/root")
+		fmt.Println("at least one of the three should be present: --root, --series, --movies")
+		fmt.Println("\nOptions:")
+		help_help(false)
+		help_version(false)
+		help_root(false)
+		help_series(false)
+		help_movies(false)
+		help_ken(false)
+		help_sen(false)
+		help_ns(false)
+	case "-h", "--help":
+		help_help(true)
+	case "-v", "--version":
+		help_version(true)
+	case "-r", "--root":
+		help_root(true)
+	case "-s", "--series":
+		help_series(true)
+	case "-m", "--movies":
+		help_movies(true)
+	case "-ken", "--keep-ep-nums":
+		help_ken(true)
+	case "-sen", "--starting-ep-num":
+		help_sen(true)
+	case "-s0", "--has-season-0":
+		help_s0(true)
+	case "-ns", "--naming-scheme":
+		help_ns(true)
+	default:
+		fmt.Printf("invalid flag: %s\n\n", flag)
+		help("")
+	}
+}
+
+func help_help(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--help | -h] <flag>", 
+			"Show this help message if no flag is specified. Shows the specific help message if a flag is specified.\n")
+	if verbose {
+		fmt.Println("  example: gorn -h")
+		fmt.Println("  example: gorn -h --naming-scheme (this will give more specific help on the naming scheme flag)")
+		fmt.Println("  example: gorn -h --keep-ep-num (this will give more specific help on the keep-ep-num flag)")
+	}
+}
+
+func help_version(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--version | -v]",
+		"Show version\n")
+	if verbose {
+		fmt.Println("  example: gorn -v")
+		fmt.Println("  version:", version)
+	}
+}
+
+func help_root(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--root | -r] path/to/root",
+		"Root directory containing series root and movie root\n\n")
+	if verbose {
+		fmt.Printf("  example: gorn -r /path/to/root\n\n")
+		fmt.Println("  Root directory should contain series and movie roots where each root should contain series and movie entries respectively.")
+		fmt.Println("  example root directory:")
+		fmt.Println("  root")
+		fmt.Println("  |__series")
+		fmt.Println("  |  |__series title")
+		fmt.Println("  |     |__media files, extra dirs, etc...")
+		fmt.Println("  |")
+		fmt.Println("  |__movies")
+		fmt.Println("     |__movie title")
+		fmt.Println("        |__media files, extra dirs, etc...")
+	}
+}
+
+func help_series(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--series | -s] path/to/series/root",
+			"Series directory containing series entries\n\n")
+	if verbose {
+		fmt.Println("  example: gorn -s /path/to/series/root")
+		fmt.Println("\n  Series directory should contain series entries.")
+		fmt.Println("  example series directory:")
+		fmt.Println("  series root")
+		fmt.Println("  |__series title")
+		fmt.Println("  |  |__media files, extra dirs, etc...")
+		fmt.Println("  |")
+		fmt.Println("  |__series entry 2")
+		fmt.Println("  |  |__media files, extra dirs, etc...")
+		fmt.Println("  |")
+		fmt.Println("  |__series entry 3")
+		fmt.Println("     |__media files, extra dirs, etc...")
+	}
+}
+
+func help_movies(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--movies | -m] path/to/movies/root",
+			"Movies directory containing movie entries\n\n")
+	if verbose {
+		fmt.Println("  example: gorn -m /path/to/movies/root")
+		fmt.Println("\n  Movies directory should contain movie entries.")
+		fmt.Println("  example movies directory:")
+		fmt.Println("  movies root")
+		fmt.Println("  |__movie title")
+		fmt.Println("  |  |__media files, extra dirs, etc...")
+		fmt.Println("  |")
+		fmt.Println("  |__movie entry 2")
+		fmt.Println("  |  |__media files, extra dirs, etc...")
+		fmt.Println("  |")
+		fmt.Println("  |__movie entry 3")
+		fmt.Println("     |__media files, extra dirs, etc...")
+	}
+}
+
+func help_ken(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--keep-ep-num | -ken] <all yes/no/default | var>",
+			"Keep original episode numbers in filename based on common naming patterns\n\n")
+	if verbose {
+		fmt.Println("  common naming patterns taken into account are:")
+		fmt.Println("    S01E02     |  S03.E04  | S05_E06 | S07-E08 | S09xE10 | S11 E12")
+		fmt.Println("    01.02      |   03_04   |  05-06  |  07x08  | 09 10 ")
+		fmt.Println("    Episode 01 | Episode02 |  EP03   |  EP-04  | E_05 | EP.06")
+		fmt.Println("\n  '.', '-', 'x', '_', and ' ' are valid season-episode separators.")
+		fmt.Println("  NOTE: This is not how the default naming scheme looks like in gorn. These common naming cases are just here to read the episode number from the filename.")
+		fmt.Println("        second number is episode")
+		fmt.Println("        if no common naming pattern is found, the file will not be renamed.")
+		fmt.Println("\n  examples: gorn -ken all yes")
+		fmt.Println("            gorn -ken all no")
+		fmt.Println("            gorn -ken all default")
+		fmt.Println("            gorn -ken var")
+	}
+}
+
+func help_sen(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--starting-ep-num | -sen] <all int/default | var>",
+			"Set the starting episode number in renaming.\n")
+	if verbose {
+		fmt.Println("\n  This can be useful if episodes are in absolute order but in different season directories for separation")
+		fmt.Println("  User can specify different starting episode number for each of those seasons")
+		fmt.Println("\n  examples: gorn -sen all 1")
+		fmt.Println("            gorn -sen all 25")
+		fmt.Println("            gorn -sen all default")
+		fmt.Println("            gorn -sen var")
+	}
+}
+
+func help_s0(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--has-season-0 | -s0] <all yes/no/default | var>",
+			"Treat extras/specials/OVA/etc directory as season 0\n")
+	if verbose {
+		fmt.Println("\n  Note that if this is set, there must be only one specials/extras/OVA directory under a series entry")
+		fmt.Println("\n  This is more useful if specified at the series entry level by doing")
+		fmt.Println("  'gorn -r path/to/root -s0 var'")
+		fmt.Println("  This will let gorn prompt the user at: per series type level and per series entry level")
+		fmt.Println("  if var is inputted at the per series type level, it will prompt the user at per series entry level which is where this flag will be most useful")
+		fmt.Println("\n  examples: gorn -s0 all yes")
+		fmt.Println("            gorn -s0 all no")
+		fmt.Println("            gorn -s0 all default")
+		fmt.Println("            gorn -s0 var")
+	}
+}
+
+func help_ns(verbose bool) {
+	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme>/default",
+			"Change the naming scheme\n")
+	if verbose {
+		fmt.Println("\n  examples: gorn -ns default")
+		fmt.Println(`            gorn -ns "S<season_num>E<episode_num> <parent: 1,5> <parent-parent: '_(\d+)_'> <p-3: 2,5> [<self: '\.(\w+)$'>]"`)
+		fmt.Println("\n  Naming Scheme APIs:")
+		fmt.Println("    1. <season_num>")
+		fmt.Println("       represents the season number which is based on series type, and directory structure and naming")
+		fmt.Println("       additional option for season num is padding with 0s")
+		fmt.Println(`         "<season_num: 2>" pads the result to 2 digits`)
+		fmt.Println(`         "<season_num: 3>" pads the result to 3 digits, etc...`)
+		fmt.Println("\n    2. <episode_num>")
+		fmt.Println("       represents the episode number which is either read from the filename or generated based on the `--keep-ep-nums` and `--starting-ep-num` flags")
+		fmt.Println("       additional option for episode num is padding with 0s just like `<season_num>`")
+		fmt.Println("\n    3. <parent> | <p>")
+		fmt.Println("       represents the parent directory of the media file. if no option was specified, it will copy the whole name of the parent directory")
+		fmt.Println(`       additional option is to select characters from the parent directory name.`)
+		fmt.Println(`         range: "<parent: 0,3>" which will copy the first 4 characters of the parent directory name`)
+		fmt.Println(`         regex: "<parent: 'S(\d+)'>" which will copy the capture group "(\d+)" that is prepended by "S" from the parent directory name`)
+		fmt.Println()
+		fmt.Println("         Notes on regex:")
+		fmt.Println(`           it can only have one capture group per part`)
+		fmt.Println(`           each part is separated by "|"`)
+		fmt.Println(`             ie. "S(\d+)|E(\d+)" is valid. It has one capture group per part and has 2 parts`)
+		fmt.Println(`             ie. "S(E|\d+)" has one capture group and one part.`)
+		fmt.Println(`                 "|" inside parenthesis does not count as a part separator. only "|" outside parenthesis is part separator`)
+		fmt.Println(`             ie. "'S(E)(\d+)|S(\d+)" is invalid since the first part has 2 capture groups, even if the second part has only 1 capture group`)
+		fmt.Println()
+		fmt.Println(`     another additional option is going above just the parent of the current directory.`)
+		fmt.Println(`         "<parent-parent>" which will copy the parent of the parent directory`)
+		fmt.Println(`         "<parent-parent: 0,4>" which will copy the first 4 characters of the parent of the parent directory`)
+		fmt.Println(`         "<p>": short form. "<p>" is equivalent to "<parent>" in every way`)
+		fmt.Println(`         "<p-2>": you can specify how much further up the directory tree you want to go by appending a number`)
+		fmt.Println(`         "<p-2: _(\d+)_>" is equivalent to "<parent-parent: _(\d+)_>" in every way`)
+		fmt.Println("\n    4. <self>")
+		fmt.Println("       same as parent but instead of being based on the parent directory name, it is based on the name of the media file before renaming it")
+		fmt.Println("       additional options are the same as well except for `<p-number>`. self has no short form")
+	}
+}

--- a/help.go
+++ b/help.go
@@ -172,7 +172,7 @@ func help_s0(verbose bool) {
 }
 
 func help_ns(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme>/default",
+	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme>/default/var",
 			"Change the naming scheme\n")
 	if verbose {
 		fmt.Println("\n  examples: gorn -ns default")

--- a/main.go
+++ b/main.go
@@ -15,9 +15,10 @@ func main() {
 	}
 
 	args, err := parse_args(os.Args[1:])
-	if err != nil && err.Error() != "safe exit" {
-		panic(err)
-	} else if err.Error() == "safe exit" {
+	if err != nil {
+		if err.Error() != "safe exit" {
+			panic(err)
+		}
 		return
 	}
 
@@ -112,7 +113,7 @@ func main() {
 	}
 
 	fmt.Println("test for named seasons")
-	named_season_options := prompt_additional_options(args.options, "all named seasons")
+	named_season_options := prompt_additional_options(args.options, "all named seasons", 0)
 	for _, v := range series.named_seasons {
 		info, err := series_rename_prereqs(v, "named_seasons", named_season_options)
 		if err != nil {
@@ -128,7 +129,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season no movies")
-	ssnm_options := prompt_additional_options(args.options, "all single season with no movies")
+	ssnm_options := prompt_additional_options(args.options, "all single season with no movies", 0)
 	for _, v := range series.single_season_no_movies {
 		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_options)
 		if err != nil {
@@ -144,7 +145,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season with movies")
-	sswm_options := prompt_additional_options(args.options, "all single season with movies")
+	sswm_options := prompt_additional_options(args.options, "all single season with movies", 0)
 	for _, v := range series.single_season_with_movies {
 		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_options)
 		if err != nil {
@@ -160,7 +161,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season no movies")
-	msnm_options := prompt_additional_options(args.options, "all multiple season with no movies")
+	msnm_options := prompt_additional_options(args.options, "all multiple season with no movies", 0)
 	for _, v := range series.multiple_season_no_movies {
 		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_options)
 		if err != nil {
@@ -176,7 +177,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season with movies")
-	mswm_options := prompt_additional_options(args.options, "all multiple season with movies")
+	mswm_options := prompt_additional_options(args.options, "all multiple season with movies", 0)
 	for _, v := range series.multiple_season_with_movies {
 		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_options)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -31,11 +31,11 @@ func main() {
 			fmt.Println("\t", movie)
 		}
 	}
-	ken, err := args.options.has_season_0.get()
+	ken, err := args.options.keep_ep_nums.get()
 	if err == nil {
 		fmt.Println("keep episode numbers: ", ken)
 	}
-	sen, err := args.options.has_season_0.get()
+	sen, err := args.options.starting_ep_num.get()
 	if err == nil {
 		fmt.Println("starting episode number: ", sen)
 	}

--- a/main.go
+++ b/main.go
@@ -31,15 +31,15 @@ func main() {
 			fmt.Println("\t", movie)
 		}
 	}
-	ken, err := args.keep_ep_nums.get()
+	ken, err := args.options.has_season_0.get()
 	if err == nil {
 		fmt.Println("keep episode numbers: ", ken)
 	}
-	sen, err := args.starting_ep_num.get()
+	sen, err := args.options.has_season_0.get()
 	if err == nil {
 		fmt.Println("starting episode number: ", sen)
 	}
-	ns, err := args.naming_scheme.get()
+	ns, err := args.options.has_season_0.get()
 	if err == nil {
 		fmt.Println("naming scheme: ", ns)
 	}
@@ -104,10 +104,9 @@ func main() {
 	}
 
 	fmt.Println("test for named seasons")
-	named_season_ken, named_season_sen, named_season_s0, named_season_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&named_season_ken, &named_season_sen, &named_season_s0, &named_season_ns, "named seasons")
+	named_season_options := prompt_additional_options(args.options, "all named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", named_season_ken, named_season_sen, named_season_s0, named_season_ns)
+		info, err := series_rename_prereqs(v, "named_seasons", named_season_options)
 		if err != nil {
 			panic(err)
 		}
@@ -121,10 +120,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season no movies")
-	ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&ssnm_ken, &ssnm_sen, &ssnm_s0, &ssnm_ns, "single season no movies")
+	ssnm_options := prompt_additional_options(args.options, "all single season with no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns)
+		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_options)
 		if err != nil {
 			panic(err)
 		}
@@ -138,10 +136,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season with movies")
-	sswm_ken, sswm_sen, sswm_s0, sswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&sswm_ken, &sswm_sen, &sswm_s0, &sswm_ns, "single season with movies")
+	sswm_options := prompt_additional_options(args.options, "all single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_ken, sswm_sen, sswm_s0, sswm_ns)
+		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_options)
 		if err != nil {
 			panic(err)
 		}
@@ -155,10 +152,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season no movies")
-	msnm_ken, msnm_sen, msnm_s0, msnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&msnm_ken, &msnm_sen, &msnm_s0, &msnm_ns, "multiple season no movies")
+	msnm_options := prompt_additional_options(args.options, "all multiple season with no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_ken, msnm_sen, msnm_s0, msnm_ns)
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_options)
 		if err != nil {
 			panic(err)
 		}
@@ -172,10 +168,9 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season with movies")
-	mswm_ken, mswm_sen, mswm_s0, mswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
-	prompt_additional_options(&mswm_ken, &mswm_sen, &mswm_s0, &mswm_ns, "multiple season with movies")
+	mswm_options := prompt_additional_options(args.options, "all multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_ken, mswm_sen, mswm_s0, mswm_ns)
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_options)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -104,8 +104,10 @@ func main() {
 	}
 
 	fmt.Println("test for named seasons")
+	named_season_ken, named_season_sen, named_season_s0, named_season_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&named_season_ken, &named_season_sen, &named_season_s0, &named_season_ns, "named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "named_seasons", named_season_ken, named_season_sen, named_season_s0, named_season_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -117,10 +119,13 @@ func main() {
 		}
 	}
 	fmt.Println()
+	// panic("test")
 
 	fmt.Println("test for single season no movies")
+	ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&ssnm_ken, &ssnm_sen, &ssnm_s0, &ssnm_ns, "single season no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true), none[string]())
+		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -134,8 +139,10 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season with movies")
+	sswm_ken, sswm_sen, sswm_s0, sswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&sswm_ken, &sswm_sen, &sswm_s0, &sswm_ns, "single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_ken, sswm_sen, sswm_s0, sswm_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -149,8 +156,10 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season no movies")
+	msnm_ken, msnm_sen, msnm_s0, msnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&msnm_ken, &msnm_sen, &msnm_s0, &msnm_ns, "multiple season no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_ken, msnm_sen, msnm_s0, msnm_ns)
 		if err != nil {
 			panic(err)
 		}
@@ -164,8 +173,10 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season with movies")
+	mswm_ken, mswm_sen, mswm_s0, mswm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme
+	prompt_additional_options(&mswm_ken, &mswm_sen, &mswm_s0, &mswm_ns, "multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_ken, mswm_sen, mswm_s0, mswm_ns)
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -105,7 +105,7 @@ func main() {
 
 	fmt.Println("test for named seasons")
 	for _, v := range series.named_seasons {
-		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "named_seasons", some[bool](false), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -120,7 +120,7 @@ func main() {
 
 	fmt.Println("test for single season no movies")
 	for _, v := range series.single_season_no_movies {
-		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true))
+		info, err := series_rename_prereqs(v, "single_season_no_movies", some[bool](false), some[int](1), some[bool](true), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -135,7 +135,7 @@ func main() {
 
 	fmt.Println("test for single season with movies")
 	for _, v := range series.single_season_with_movies {
-		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "single_season_with_movies", some[bool](true), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -150,7 +150,7 @@ func main() {
 
 	fmt.Println("test for multiple season no movies")
 	for _, v := range series.multiple_season_no_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "multiple_season_no_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}
@@ -165,7 +165,7 @@ func main() {
 
 	fmt.Println("test for multiple season with movies")
 	for _, v := range series.multiple_season_with_movies {
-		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false))
+		info, err := series_rename_prereqs(v, "multiple_season_with_movies", some[bool](false), some[int](1), some[bool](false), none[string]())
 		if err != nil {
 			panic(err)
 		}

--- a/main.go
+++ b/main.go
@@ -119,7 +119,6 @@ func main() {
 		}
 	}
 	fmt.Println()
-	// panic("test")
 
 	fmt.Println("test for single season no movies")
 	ssnm_ken, ssnm_sen, ssnm_s0, ssnm_ns := args.keep_ep_nums, args.starting_ep_num, args.has_season_0, args.naming_scheme

--- a/main.go
+++ b/main.go
@@ -7,10 +7,18 @@ import (
 	"strings"
 )
 
+var version string
 func main() {
+	if len(os.Args) < 2 {
+		welcome_msg(version)
+		return
+	}
+
 	args, err := parse_args(os.Args[1:])
-	if err != nil {
+	if err != nil && err.Error() != "safe exit" {
 		panic(err)
+	} else if err.Error() == "safe exit" {
+		return
 	}
 
 	if len(args.root) > 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -438,13 +439,16 @@ func Test_split_regex_by_pipe(t *testing.T) {
 func Test_generate_new_name(t *testing.T) {
 	path := filepath.Clean(`.test_files\Series\Series_seasonal\Season 1\1234567890.mp4`)
 	t.Log("------------expects success------------")
-	name, err := generate_new_name(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,6>`),
+	name, err := generate_new_name(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`),
 									2, 1, 3, 2,
-									"title", ".ext",
-									path)
+									"title", path)
 	if err != nil {
 		t.Error(err)
 	} else {
-		t.Log("\n\told: ", `S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`, "\n\tnew: ", name)
+		if strings.ReplaceAll(name, "S001E02 - Series Season ies 6.mp4", "") != "" {
+			t.Errorf("expected 'S001E02 - Series Season ies 6.mp4' got '%s'", name)
+		} else {
+			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: '.*r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
+		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -443,12 +443,12 @@ func Test_generate_new_name(t *testing.T) {
 									2, 1, 3, 2,
 									"title", path)
 	if err != nil {
-		t.Error(err)
+		t.Error("expected no error; got", err)
 	} else {
-		if strings.ReplaceAll(name, "S001E02 - Series Season ies 6.mp4", "") != "" {
-			t.Errorf("expected 'S001E02 - Series Season ies 6.mp4' got '%s'", name)
+		if strings.ReplaceAll(name, `.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4`, "") != "" {
+			t.Errorf(`expected '.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4' got '%s'`, name)
 		} else {
-			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: '.*r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
+			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
 		}
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -342,6 +342,13 @@ func Test_naming_scheme_validation(t *testing.T) {
 	} else {
 		t.Log(`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`)
 	}
+
+	err = validate_naming_scheme(`<p> <p-2>`)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(`<p>`)
+	}
 }
 
 func Test_split_regex_by_pipe(t *testing.T) {
@@ -444,4 +451,18 @@ func Test_generate_new_name(t *testing.T) {
 			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
 		}
 	}
+
+	name, err = generate_new_name(some[string](`<p>`), 
+									2, 1, 3, 2, 
+									"title", path)
+	if err != nil {
+		t.Error("expected no error; got", err)
+	} else {
+		if strings.ReplaceAll(name, `.test_files\Series\Series_seasonal\Season 1\Season 1.mp4`, "") != "" {
+			t.Errorf(`expected '.test_files\Series\Series_seasonal\Season 1\Season 1.mp4' got '%s'`, name)
+		} else {
+			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `<p> <p-2>`, "\n\tnew:\t\t", name)
+		}
+	}
+
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -15,20 +16,20 @@ func Test_parse_args(t *testing.T) {
 		t.Log("--root", "--series", "--movies", "\n\t", err, "\n")
 	}
 
-	command =[]string{"-r", "-s", "-m"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root dir path'")
-	} else {
-		t.Log("-r", "-s", "-m", "\n\t", err, "\n")
-	}
-
 	command =[]string{"-s", "--series", "-r", "--root",  "-m", "--movies"}
 	_, err = parse_args(command)
 	if err == nil {
 		t.Errorf("expected error 'missing series dir path'")
 	} else {
 		t.Log("-s", "--series", "-r", "--root",  "-m", "--movies", "\n\t", err, "\n")
+	}
+
+	command =[]string{"-r", "-s", "-m"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'missing root dir path'")
+	} else {
+		t.Log("-r", "-s", "-m", "\n\t", err, "\n")
 	}
 
 	command =[]string{"-m", "--movies", "-r", "--root",  "-s", "--series"}
@@ -46,14 +47,6 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("--root", "./test_files", "./test_files", "\n\t", err, "\n")
 	}
-	
-	command = []string{"-s", "./test_files", "./test_files"} 
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple values for one flag is not allowed'")
-	} else {
-		t.Log("-s", "./test_files", "./test_files", "\n\t", err, "\n")
-	}
 
 	command = []string{"-m", "./test_files", "./test_files"}
 	_, err = parse_args(command)
@@ -61,6 +54,14 @@ func Test_parse_args(t *testing.T) {
 		t.Errorf("expected error 'multiple values for one flag is not allowed'")
 	} else {
 		t.Log("-m", "./test_files", "./test_files", "\n\t", err, "\n")
+	}
+	
+	command = []string{"-s", "./test_files", "./test_files"} 
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'multiple values for one flag is not allowed'")
+	} else {
+		t.Log("-s", "./test_files", "./test_files", "\n\t", err, "\n")
 	}
 
 	command = []string{"./test_files"}
@@ -71,20 +72,20 @@ func Test_parse_args(t *testing.T) {
 		t.Log("./test_files", "\n\t", err, "\n")
 	}
 
-	command = []string{"-s0", "all", "yes"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root/series/movies dir path'")
-	} else {
-		t.Log("-s0", "all", "yes", "\n\t", err, "\n")
-	}
-
 	command = []string{"-r", "./test_files", "--season-0", "all", "1"}
 	_, err = parse_args(command)
 	if err == nil {
 		t.Errorf("expected error '1 is not a valid arg. must be yes or no'")
 	} else {
 		t.Log("-r", "./test_files", "--season-0", "all", "1", "\n\t", err, "\n")
+	}
+
+	command = []string{"-s0", "all", "yes"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'missing root/series/movies dir path'")
+	} else {
+		t.Log("-s0", "all", "yes", "\n\t", err, "\n")
 	}
 
 	command = []string{"-r", "./test_files", "--season-0", "yes"}
@@ -95,14 +96,6 @@ func Test_parse_args(t *testing.T) {
 		t.Log("-r", "./test_files", "--season-0", "yes", "\n\t", err, "\n")
 	}
 
-	command = []string{"-r", "./test_files", "--season-0", "-s0"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error '-s0 is not a valid arg. must be all or var'")
-	} else {
-		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
-	}
-
 	command = []string{"-ken", "all", "yes"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -110,7 +103,7 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("-ken", "all", "yes", "\n\t", err, "\n")
 	}
-
+	
 	command = []string{"-r", "./test_files", "-ken", "all", "1"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -119,6 +112,14 @@ func Test_parse_args(t *testing.T) {
 		t.Log("-r", "./test_files", "-ken", "all", "1", "\n\t", err, "\n")
 	}
 
+	command = []string{"-r", "./test_files", "--season-0", "-s0"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error '-s0 is not a valid arg. must be all or var'")
+	} else {
+		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
+	}
+	
 	command = []string{"-r", "./test_files", "-ken", "yes"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -166,23 +167,7 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
 	}
-
-	command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple starting-ep-num flags'")
-	} else {
-		t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
-	}
 	
-	command = []string{"--root", `C:\Users\Cid\Documents\projects\Go\gorn\test_files`, "-s", `C:\Users\Cid\Documents\Projects\Go\gorn\test_files\Series`, "-m", "./test_files/Movies"}
-	_, err = parse_args(command)
-	if err == nil {
-		t.Errorf("expected error 'series directory ./test_files/Series is a subdirectory of root directory ./test_files'")
-	} else {
-		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
-	}
-
 	command = []string{"--root", "./test_files", "-r", "./test_files"}
 	_, err = parse_args(command)
 	if err == nil {
@@ -190,23 +175,39 @@ func Test_parse_args(t *testing.T) {
 	} else {
 		t.Log("--root", "./test_files", "-r", "./test_files", "\n\t", err, "\n")
 	}
-
-	t.Log("------------expects success------------")
-
-	command = []string{"--root", "./test_files"}
+	
+	command = []string{"--root", `.\test_files`, "-s", `.\test_files\Series`, "-m", "./test_files/Movies"}
 	_, err = parse_args(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+	if err == nil {
+		t.Errorf("expected error 'series directory ./test_files/Series is a subdirectory of root directory ./test_files'")
 	} else {
-		t.Log("--root", "./test_files")
+		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
 	}
-
+	
+	
+		command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
+		_, err = parse_args(command)
+		if err == nil {
+			t.Errorf("expected error 'multiple starting-ep-num flags'")
+		} else {
+			t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
+		}
+	t.Log("------------expects success------------")
+	
 	command = []string{"--root", "./test_files", "-s0", "all", "yes"}
 	_, err = parse_args(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
 		t.Log("--root", "./test_files", "-s0", "all", "yes")
+	}
+	
+	command = []string{"--root", "./test_files"}
+	_, err = parse_args(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log("--root", "./test_files")
 	}
 
 	command = []string{"--root", "./test_files", "-s0"}
@@ -226,26 +227,19 @@ func Test_naming_scheme_validation(t *testing.T) {
 	} else {
 		t.Log("S<season_num:>E<episode_num:>", "\n\t", err, "\n")
 	}
-
-	err = validate_naming_scheme(`S<season_num: 3`)
-	if err == nil {
-		t.Errorf("expected error 'reached end of string but still in an unclosed api: <season_num: 3'")
-	} else {
-		t.Log(`S<season_num: 3`, "\n\t", err, "\n")
-	}
-
+	
 	err = validate_naming_scheme(`S<season_num: 3l>`)
 	if err == nil {
 		t.Errorf("expected error '3l is not a valid arg. must be a valid positive integer'")
 	} else {
 		t.Log(`S<season_num: 3l>`, "\n\t", err, "\n")
 	}
-
-	err = validate_naming_scheme(`E<episode_num: -2>`)
+		
+	err = validate_naming_scheme(`S<season_num: 3`)
 	if err == nil {
-		t.Errorf("expected error '-2 is not a valid arg. must be a valid positive integer'")
+		t.Errorf("expected error 'reached end of string but still in an unclosed api: <season_num: 3'")
 	} else {
-		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
+		t.Log(`S<season_num: 3`, "\n\t", err, "\n")
 	}
 
 	err = validate_naming_scheme(`<parent-parent:>`)
@@ -254,7 +248,14 @@ func Test_naming_scheme_validation(t *testing.T) {
 	} else {
 		t.Log(`<parent-parent:>`, "\n\t", err, "\n")
 	}
-
+	
+	err = validate_naming_scheme(`E<episode_num: -2>`)
+	if err == nil {
+		t.Errorf("expected error '-2 is not a valid arg. must be a valid positive integer'")
+	} else {
+		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
+	}
+	
 	err = validate_naming_scheme(`<parent-parent:1>`)
 	if err == nil {
 		t.Errorf("expected error '1 is not a valid arg. must be two valid positive integers separated by a comma'")
@@ -430,5 +431,20 @@ func Test_split_regex_by_pipe(t *testing.T) {
 		for _, part := range parts {
 			t.Log("\t",part, "has only one match group?", has_only_one_match_group(part))
 		}
+	}
+}
+
+
+func Test_generate_new_name(t *testing.T) {
+	path := filepath.Clean(`.test_files\Series\Series_seasonal\Season 1\1234567890.mp4`)
+	t.Log("------------expects success------------")
+	name, err := generate_new_name(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,6>`),
+									2, 1, 3, 2,
+									"title", ".ext",
+									path)
+	if err != nil {
+		t.Error(err)
+	} else {
+		t.Log("\n\told: ", `S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`, "\n\tnew: ", name)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -116,7 +116,7 @@ func Test_parse_args(t *testing.T) {
 	command = []string{"-r", "./test_files", "--season-0", "-s0"}
 	_, err = parse_args(command)
 	if err == nil {
-		t.Errorf("expected error '-s0 is not a valid arg. must be all or var'")
+		t.Errorf("expected error 'only one of --season-0 and -s0 is allowed'")
 	} else {
 		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
 	}
@@ -186,13 +186,13 @@ func Test_parse_args(t *testing.T) {
 	}
 	
 	
-		command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
-		_, err = parse_args(command)
-		if err == nil {
-			t.Errorf("expected error 'multiple starting-ep-num flags'")
-		} else {
-			t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
-		}
+	command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
+	_, err = parse_args(command)
+	if err == nil {
+		t.Errorf("expected error 'multiple starting-ep-num flags'")
+	} else {
+		t.Log("-r", "./test_files", "--naming-scheme", "S01E01", "\n\t", err, "\n")
+	}
 	t.Log("------------expects success------------")
 	
 	command = []string{"--root", "./test_files", "-s0", "all", "yes"}

--- a/main_test.go
+++ b/main_test.go
@@ -257,13 +257,6 @@ func Test_naming_scheme_validation(t *testing.T) {
 		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
 	}
 	
-	err = validate_naming_scheme(`<parent-parent:1>`)
-	if err == nil {
-		t.Errorf("expected error '1 is not a valid arg. must be two valid positive integers separated by a comma'")
-	} else {
-		t.Log(`<parent-parent:1>`, "\n\t", err, "\n")
-	}
-
 	err = validate_naming_scheme(`<parent-parent:1,>`)
 	if err == nil {
 		t.Errorf("expected error '1, is not a valid arg. must be two valid positive integers separated by a comma'")

--- a/parse_args.go
+++ b/parse_args.go
@@ -48,6 +48,9 @@ func parse_args(args []string) (Args, error) {
 		"--movies": true,
 		"-m":       true,
 	}
+	assigned := map[string]bool {
+		"--options": false,
+	}
 
 	parsed_args := new_Args()
 	skip_iter := 0
@@ -178,6 +181,31 @@ func parse_args(args []string) (Args, error) {
 				parsed_args.options.starting_ep_num = none[int]()
 			}
 
+		} else if arg == "--options" || arg == "-o" {
+			if assigned["--options"] {
+				return Args{}, fmt.Errorf("only one --options flag is allowed")
+			}
+			
+			// all options are assigned `var`
+			if len(args) <= i+1 || (len(args) > i+1 && (args[i+1][0] == '-' || args[i+1] == "var")) {
+				assigned["--options"] = true
+				parsed_args.options.keep_ep_nums = none[bool]()
+				parsed_args.options.starting_ep_num = none[int]()
+				parsed_args.options.has_season_0 = none[bool]()
+				parsed_args.options.naming_scheme = none[string]()
+
+			} else if args[i+1] != "default" && args[i+1] != "var" {
+				return Args{}, fmt.Errorf("invalid value '%s' for --options. Must be 'default' or 'var", args[i+1])
+
+			} else if args[i+1] == "default" {
+				// use default values
+				assigned["--options"] = true
+				parsed_args.options.keep_ep_nums = some[bool](false)
+				parsed_args.options.starting_ep_num = some[int](1)
+				parsed_args.options.has_season_0 = some[bool](false)
+				parsed_args.options.naming_scheme = some[string]("default")
+			}
+
 		} else if arg == "--naming-scheme" || arg == "-ns" {
 			if parsed_args.options.naming_scheme.is_some() {
 				return Args{}, fmt.Errorf("only one --naming-scheme flag is allowed")
@@ -215,18 +243,20 @@ func parse_args(args []string) (Args, error) {
 		return Args{}, err
 	}
 
-	// use default values for additional options
-	if parsed_args.options.has_season_0.is_none() {
-		parsed_args.options.has_season_0 = some[bool](false)
-	}
-	if parsed_args.options.keep_ep_nums.is_none() {
-		parsed_args.options.keep_ep_nums = some[bool](false)
-	}
-	if parsed_args.options.starting_ep_num.is_none() {
-		parsed_args.options.starting_ep_num = some[int](1)
-	}
-	if parsed_args.options.naming_scheme.is_none() {
-		parsed_args.options.naming_scheme = some[string]("default")
+	if !assigned["--options"] {
+		// use default values for additional options
+		if parsed_args.options.has_season_0.is_none() {
+			parsed_args.options.has_season_0 = some[bool](false)
+		}
+		if parsed_args.options.keep_ep_nums.is_none() {
+			parsed_args.options.keep_ep_nums = some[bool](false)
+		}
+		if parsed_args.options.starting_ep_num.is_none() {
+			parsed_args.options.starting_ep_num = some[int](1)
+		}
+		if parsed_args.options.naming_scheme.is_none() {
+			parsed_args.options.naming_scheme = some[string]("default")
+		}
 	}
 	return parsed_args, nil
 }

--- a/parse_args.go
+++ b/parse_args.go
@@ -226,9 +226,8 @@ func parse_args(args []string) (Args, error) {
 		parsed_args.options.starting_ep_num = some[int](1)
 	}
 	if parsed_args.options.naming_scheme.is_none() {
-		parsed_args.options.naming_scheme = none[string]()
+		parsed_args.options.naming_scheme = some[string]("default")
 	}
-
 	return parsed_args, nil
 }
 

--- a/parse_args.go
+++ b/parse_args.go
@@ -293,7 +293,7 @@ func validate_naming_scheme(s string) error {
 			// valid range
 			res := strings.SplitN(val, ",", 2)
 			begin, end := strings.TrimSpace(res[0]), strings.TrimSpace(res[1])
-			if begin >= end {
+			if begin > end {
 				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than end (%s)", val, begin, end)
 			}
 		}

--- a/parse_args.go
+++ b/parse_args.go
@@ -293,8 +293,8 @@ func validate_naming_scheme(s string) error {
 			// valid range
 			res := strings.SplitN(val, ",", 2)
 			begin, end := strings.TrimSpace(res[0]), strings.TrimSpace(res[1])
-			if begin > end {
-				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than or equal to end (%s)", val, begin, end)
+			if begin >= end {
+				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than end (%s)", val, begin, end)
 			}
 		}
 	}

--- a/parse_args.go
+++ b/parse_args.go
@@ -221,7 +221,7 @@ func validate_naming_scheme(s string) error {
 
 	valid_api := regexp.MustCompile(`^season_num$|^episode_num$|^self$`)
 	valid_parent_api := regexp.MustCompile(`^parent(-parent)*$|^p(-\d+)?$`)
-	valid_range := regexp.MustCompile(`^\d+(,\s*\d+)?$`)
+	valid_range := regexp.MustCompile(`^\d+(\s*,\s*\d+)?$`)
 
 	for _,token := range tokens {
 		var api, val string

--- a/parse_args.go
+++ b/parse_args.go
@@ -62,6 +62,18 @@ func parse_args(args []string) (Args, error) {
 		// catch invalid values acting as flags
 		} else if arg[0] != '-' {
 			return Args{}, fmt.Errorf("invalid flag: '%s'", arg)
+		
+		} else if arg == "--help" || arg == "-h" {
+			if len(args) <= i+1 {
+				help("")
+			} else if len(args) > i+1 {
+				help(args[i+1])
+			}
+			return Args{}, fmt.Errorf("safe exit")
+		
+		} else if arg == "--version" || arg == "-v" {
+			welcome_msg(version)
+			return Args{}, fmt.Errorf("safe exit")
 
 		} else if directory_args[arg] {
 			// no value after flag / flag after flag

--- a/parse_args.go
+++ b/parse_args.go
@@ -10,12 +10,15 @@ import (
 )
 
 type Args struct {
-	root            []string
-	series          []string
-	movies          []string
-	has_season_0    Option[bool]
+	root            	[]string
+	series          	[]string
+	movies          	[]string
+	options 	AdditionalOptions
+}
+type AdditionalOptions struct {
 	keep_ep_nums    Option[bool]
 	starting_ep_num Option[int]
+	has_season_0    Option[bool]
 	naming_scheme   Option[string]
 }
 func new_Args() Args {
@@ -23,10 +26,12 @@ func new_Args() Args {
 		root:            make([]string, 0),
 		series:          make([]string, 0),
 		movies:          make([]string, 0),
-		has_season_0:    none[bool](),
-		keep_ep_nums:    none[bool](),
-		starting_ep_num: none[int](),
-		naming_scheme:   none[string](),
+		options: AdditionalOptions{
+			has_season_0:    none[bool](),
+			keep_ep_nums:    none[bool](),
+			starting_ep_num: none[int](),
+			naming_scheme:   none[string](),
+		},
 	}
 }
 
@@ -80,13 +85,13 @@ func parse_args(args []string) (Args, error) {
 			skip_iter = i + 1
 
 		} else if arg == "--season-0" || arg == "-s0" {
-			if parsed_args.has_season_0.is_some() {
+			if parsed_args.options.has_season_0.is_some() {
 				return Args{}, fmt.Errorf("only one --season-0 flag is allowed")
 			}
 
 			// default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.has_season_0 = some[bool](false)
+				parsed_args.options.has_season_0 = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'all' or 'var", args[i+1], arg)
@@ -104,21 +109,21 @@ func parse_args(args []string) (Args, error) {
 				} else {
 					value = false
 				}
-				parsed_args.has_season_0 = some[bool](value)
+				parsed_args.options.has_season_0 = some[bool](value)
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.has_season_0 = none[bool]()
+				parsed_args.options.has_season_0 = none[bool]()
 			}
 
 		} else if arg == "--keep-ep-nums" || arg == "-ken" {
-			if parsed_args.keep_ep_nums.is_some() {
+			if parsed_args.options.keep_ep_nums.is_some() {
 				return Args{}, fmt.Errorf("only one --keep-ep-nums flag is allowed")
 			}
 
 			// default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.keep_ep_nums = some[bool](false)
+				parsed_args.options.keep_ep_nums = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'all' or 'var", args[i+1])
@@ -137,21 +142,21 @@ func parse_args(args []string) (Args, error) {
 				} else {
 					value = false
 				}
-				parsed_args.keep_ep_nums = some[bool](value)
+				parsed_args.options.keep_ep_nums = some[bool](value)
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.has_season_0 = none[bool]()
+				parsed_args.options.has_season_0 = none[bool]()
 			}
 
 		} else if arg == "--starting-ep-num" || arg == "-sen" {
-			if parsed_args.starting_ep_num.is_some() {
+			if parsed_args.options.starting_ep_num.is_some() {
 				return Args{}, fmt.Errorf("only one --starting-ep-num flag is allowed")
 			}
 
 			// default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.starting_ep_num = some[int](1)
+				parsed_args.options.starting_ep_num = some[int](1)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be 'all' or 'var", args[i+1])
@@ -166,15 +171,15 @@ func parse_args(args []string) (Args, error) {
 					return Args{}, fmt.Errorf("all must be followed by a positive int for --starting-ep-num. %s is not a valid positive int", args[i+2])
 				}
 
-				parsed_args.starting_ep_num = some[int](value)
+				parsed_args.options.starting_ep_num = some[int](value)
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.starting_ep_num = none[int]()
+				parsed_args.options.starting_ep_num = none[int]()
 			}
 
 		} else if arg == "--naming-scheme" || arg == "-ns" {
-			if parsed_args.naming_scheme.is_some() {
+			if parsed_args.options.naming_scheme.is_some() {
 				return Args{}, fmt.Errorf("only one --naming-scheme flag is allowed")
 			}
 
@@ -193,11 +198,11 @@ func parse_args(args []string) (Args, error) {
 					return Args{}, err
 				}
 
-				parsed_args.naming_scheme = some[string](args[i+2])
+				parsed_args.options.naming_scheme = some[string](args[i+2])
 				skip_iter = i + 2
 
 			} else if args[i+1] == "var" {
-				parsed_args.naming_scheme = none[string]()
+				parsed_args.options.naming_scheme = none[string]()
 			}
 
 		} else {

--- a/parse_args.go
+++ b/parse_args.go
@@ -89,9 +89,9 @@ func parse_args(args []string) (Args, error) {
 				return Args{}, fmt.Errorf("only one --season-0 flag is allowed")
 			}
 
-			// default value
+			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.options.has_season_0 = some[bool](false)
+				continue
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'all' or 'var", args[i+1], arg)
@@ -121,9 +121,9 @@ func parse_args(args []string) (Args, error) {
 				return Args{}, fmt.Errorf("only one --keep-ep-nums flag is allowed")
 			}
 
-			// default value
+			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.options.keep_ep_nums = some[bool](false)
+				continue
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'all' or 'var", args[i+1])
@@ -154,9 +154,9 @@ func parse_args(args []string) (Args, error) {
 				return Args{}, fmt.Errorf("only one --starting-ep-num flag is allowed")
 			}
 
-			// default value
+			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				parsed_args.options.starting_ep_num = some[int](1)
+				continue
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be 'all' or 'var", args[i+1])
@@ -213,6 +213,20 @@ func parse_args(args []string) (Args, error) {
 	err := validate_roots(parsed_args.root, parsed_args.series, parsed_args.movies)
 	if err != nil {
 		return Args{}, err
+	}
+
+	// use default values for additional options
+	if parsed_args.options.has_season_0.is_none() {
+		parsed_args.options.has_season_0 = some[bool](false)
+	}
+	if parsed_args.options.keep_ep_nums.is_none() {
+		parsed_args.options.keep_ep_nums = some[bool](false)
+	}
+	if parsed_args.options.starting_ep_num.is_none() {
+		parsed_args.options.starting_ep_num = some[int](1)
+	}
+	if parsed_args.options.naming_scheme.is_none() {
+		parsed_args.options.naming_scheme = none[string]()
 	}
 
 	return parsed_args, nil

--- a/parse_args.go
+++ b/parse_args.go
@@ -56,7 +56,7 @@ func parse_args(args []string) (Args, error) {
 		if skip_iter != 0 && i <= skip_iter {
 			continue
 
-			// catch invalid values acting as flags
+		// catch invalid values acting as flags
 		} else if arg[0] != '-' {
 			return Args{}, fmt.Errorf("invalid flag: '%s'", arg)
 
@@ -65,7 +65,7 @@ func parse_args(args []string) (Args, error) {
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
 				return Args{}, fmt.Errorf("missing dir path value for flag '%s'", arg)
 
-				// not a valid directory
+			// not a valid directory
 			} else if _, err := filepath.Abs(args[i+1]); err != nil {
 				return Args{}, err
 			}
@@ -91,7 +91,7 @@ func parse_args(args []string) (Args, error) {
 
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				continue
+				parsed_args.options.has_season_0 = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'all' or 'var", args[i+1], arg)
@@ -123,7 +123,7 @@ func parse_args(args []string) (Args, error) {
 
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				continue
+				parsed_args.options.keep_ep_nums = some[bool](false)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'all' or 'var", args[i+1])
@@ -156,7 +156,7 @@ func parse_args(args []string) (Args, error) {
 
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
-				continue
+				parsed_args.options.starting_ep_num = some[int](1)
 
 			} else if args[i+1] != "all" && args[i+1] != "var" {
 				return Args{}, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be 'all' or 'var", args[i+1])

--- a/parse_args.go
+++ b/parse_args.go
@@ -221,7 +221,7 @@ func validate_naming_scheme(s string) error {
 
 	valid_api := regexp.MustCompile(`^season_num$|^episode_num$|^self$`)
 	valid_parent_api := regexp.MustCompile(`^parent(-parent)*$|^p(-\d+)?$`)
-	valid_range := regexp.MustCompile(`^\d+,\s*\d+$`)
+	valid_range := regexp.MustCompile(`^\d+(,\s*\d+)?$`)
 
 	for _,token := range tokens {
 		var api, val string
@@ -290,11 +290,17 @@ func validate_naming_scheme(s string) error {
 			} else if !valid_range.MatchString(val) {
 				return fmt.Errorf("%s's value must be in the format <start>,<end> where <start> and <end> are positive integers and 0. '%s' is not a valid range", api, val)
 			}
+
 			// valid range
-			res := strings.SplitN(val, ",", 2)
+			var res []string
+			if strings.Contains(val, ",") {
+				res = strings.SplitN(val, ",", 2)
+			} else {
+				res = []string{val, val}
+			}
 			begin, end := strings.TrimSpace(res[0]), strings.TrimSpace(res[1])
 			if begin > end {
-				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than end (%s)", val, begin, end)
+				return fmt.Errorf("%s is an invalid range. begin (%s) must be less than or equal to end (%s)", val, begin, end)
 			}
 		}
 	}

--- a/rename.go
+++ b/rename.go
@@ -77,12 +77,12 @@ func (info *SeriesInfo) rename() error {
 		season_ken, season_sen, season_s0, season_ns := info.keep_ep_nums, info.starting_ep_num, some[bool](false), info.naming_scheme
 		prompt_additional_options(&season_ken, &season_sen, &season_s0, &season_ns, season_path)
 
-		var ep_num int
-		sen, err := season_sen.get()
-		if err != nil {
-			return err
+		var ep_num, sen int
+		if season_sen.is_some() {
+			sen, _ = season_sen.get()
+		} else {
+			sen = 1
 		}
-
 		if sen > 0 {
 			ep_num = sen
 		} else {
@@ -90,9 +90,11 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		ep_nums := make([]int, 0)
-		ken, err := season_ken.get()
-		if err != nil {
-			return err
+		var ken bool
+		if season_ken.is_some() {
+			ken, _ = season_ken.get()
+		} else {
+			ken = false
 		}
 
 		if ken {

--- a/rename.go
+++ b/rename.go
@@ -72,7 +72,7 @@ func (info *SeriesInfo) rename() error {
 		}
 		
 		// if additional options are none aka user inputted var, ask for user input
-		season_options := prompt_additional_options(info.options, season_path)
+		season_options := prompt_additional_options(info.options, season_path, 2)
 
 		var ep_num, sen int
 		if season_options.starting_ep_num.is_some() {
@@ -214,7 +214,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {
 	var new_name string
 	ns, _ := naming_scheme.get()
-	if naming_scheme.is_some() {
+	if naming_scheme.is_some() && ns != "default" {
 		scheme, err := naming_scheme.get()
 		if err != nil {
 			return "", err

--- a/rename.go
+++ b/rename.go
@@ -326,6 +326,7 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 							season_pad, season_num, 
 							ep_pad, ep_num,
 							title, filepath.Ext(abs_path))
+		new_name = filepath.Join(filepath.Dir(abs_path), new_name)
 	}
 
 	return new_name, nil

--- a/rename.go
+++ b/rename.go
@@ -73,8 +73,12 @@ func (info *SeriesInfo) rename() error {
 			max_ep_digits = 2
 		}
 		
+		// if additional options are none aka user inputted var, ask for user input
+		season_ken, season_sen, season_s0, season_ns := info.keep_ep_nums, info.starting_ep_num, some[bool](false), info.naming_scheme
+		prompt_additional_options(&season_ken, &season_sen, &season_s0, &season_ns, season_path)
+
 		var ep_num int
-		sen, err := info.starting_ep_num.get()
+		sen, err := season_sen.get()
 		if err != nil {
 			return err
 		}
@@ -86,7 +90,7 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		ep_nums := make([]int, 0)
-		ken, err := info.keep_ep_nums.get()
+		ken, err := season_ken.get()
 		if err != nil {
 			return err
 		}
@@ -114,11 +118,11 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		for i, file := range media_files {
-			title := default_title(info.series_type, info.naming_scheme, info.path, season_path)
-			new_name, err := generate_new_name(info.naming_scheme,
-										  max_season_digits, num, 	// season_pad, season_num
-										  max_ep_digits, ep_nums[i],// ep_pad, ep_num 
-										  title, file) 				// title, file path
+			title := default_title(info.series_type, season_ns, info.path, season_path)
+			new_name, err := generate_new_name(season_ns,				// naming_scheme
+										  max_season_digits, num, 		// season_pad, season_num
+										  max_ep_digits, ep_nums[i],	// ep_pad, ep_num 
+										  title, file) 					// title, file path
 			if err != nil {
 				return err
 			}

--- a/rename.go
+++ b/rename.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"sort"
+	"strings"
 )
 
 type Rename interface {
@@ -49,7 +51,6 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		season_path := filepath.Clean(info.path + "/" + season)
-
 
 		fmt.Println("path: ", season_path)
 		files, err := os.ReadDir(season_path)
@@ -113,23 +114,18 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		for i, file := range media_files {
-			var title string
-			if info.series_type == "single_season_no_movies" || info.series_type == "multiple_season_no_movies" || info.series_type == "multiple_season_with_movies" {
-				title = filepath.Base(info.path)
-			} else if info.series_type == "single_season_with_movies" {
-				title = filepath.Base(season_path)
-			} else if info.series_type == "named_seasons" {
-				title = filepath.Base(info.path) + " " + filepath.Base(season_path)
+			title := default_title(info.series_type, info.naming_scheme, info.path, season_path)
+			new_name, err := generate_new_name(info.naming_scheme,
+										  max_season_digits, num, 	// season_pad, season_num
+										  max_ep_digits, ep_nums[i],// ep_pad, ep_num 
+										  title, file) 				// title, file path
+			if err != nil {
+				return err
 			}
-			
-			new_name := fmt.Sprintf("S%0*dE%0*d %s%s",
-									max_season_digits, num, 
-									max_ep_digits, ep_nums[i],
-									clean_title(title), filepath.Ext(file))
 
 			fmt.Println(fmt.Sprintf("%-*s", 20, file), " --> ", fmt.Sprintf("%*s", 20, new_name))
 			fmt.Println("old", season_path+"/"+file, "new", season_path+"/"+new_name)
-			_, err := os.Stat(season_path+new_name)
+			_, err = os.Stat(season_path+new_name)
 			if err == nil {
 				fmt.Println("renaming", season_path+"/"+file, "to", season_path+"/"+new_name + " failed: file already exists")
 				continue
@@ -198,4 +194,120 @@ func (info *MovieInfo) rename() error {
 		}
 	}
 	return nil
+}
+
+func default_title(series_type string, naming_scheme Option[string], path string, season_path string) string {
+	var title string
+	if series_type == "single_season_no_movies" || series_type == "multiple_season_no_movies" || series_type == "multiple_season_with_movies" {
+		title = filepath.Base(path)
+	} else if series_type == "single_season_with_movies" {
+		title = filepath.Base(season_path)
+	} else if series_type == "named_seasons" {
+		title = filepath.Base(path) + " " + filepath.Base(season_path)
+	}
+	return title
+}
+
+func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, file string) (string, error) {
+	var new_name string
+	if naming_scheme.is_some() {
+		scheme, err := naming_scheme.get()
+		if err != nil {
+			return "", err
+		}
+		// replace <season_num>
+		new_name = regexp.MustCompile(`<season_num(\s*:\s*\d+)?>`).ReplaceAllStringFunc(scheme, func(match string) string {
+			// <season_num: \d+>
+			if strings.Contains(match, ":") {
+				pad := regexp.MustCompile(`\d+`).FindString(match)
+				pad_num, err := strconv.Atoi(pad)
+				if err != nil {
+					return match
+				}
+				return fmt.Sprintf("%0*d", pad_num, season_num)
+			}
+			// <season_num>
+			return fmt.Sprintf("%0*d", season_pad, season_num)
+		})
+		// replace <episode_num>
+		new_name = regexp.MustCompile(`<episode_num(\s*:\s*\d+)?>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			// <episode_num: \d+>
+			if strings.Contains(match, ":") {
+				pad := regexp.MustCompile(`\d+`).FindString(match)
+				pad_num, err := strconv.Atoi(pad)
+				if err != nil {
+					return match
+				}
+				return fmt.Sprintf("%0*d", pad_num, ep_num)
+			}
+			// <episode_num>
+			return fmt.Sprintf("%0*d", ep_pad, ep_num)
+		})
+		// replace <self: start,end> with filepath.Base(file)[start:end]
+		new_name = regexp.MustCompile(`<self\s*:\s*\d+,\d+>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
+			if len(parts) != 2 {
+				return match
+			}
+			start, err := strconv.Atoi(parts[0])
+			if err != nil {
+				return match
+			}
+			end, err := strconv.Atoi(parts[1])
+			if err != nil {
+				return match
+			}
+			fmt.Println(filepath.Base(file)[start:end])
+			return filepath.Base(file)[start:end]
+		})
+		// replace <parent> tokens with nth parent's name
+		// lol goodluck: https://regex-vis.com/?r=%3C%28parent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%7Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%29%5Cs*%3E&e=0
+		new_name = regexp.MustCompile(`<(parent(-parent)*(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?|p(-\d+)?(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?)\s*>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			n, err := parent_token_to_int(match)
+			if err != nil {
+				return match
+			}
+			parent_name := nth_parent(file, n)
+
+			if strings.Contains(match, ":") {
+				parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
+
+				if len(parts) == 2 {
+					start, err := strconv.Atoi(parts[0])
+					if err != nil {
+						return parent_name
+					}
+					end, err := strconv.Atoi(parts[1])
+					if err != nil {
+						return parent_name
+					}
+					return parent_name[start:end]
+				}
+				regex_pattern := regexp.MustCompile(`'[^']*'`).FindString(match)
+				if len(regex_pattern) > 0 {
+					regex_pattern = strings.Trim(regex_pattern, "'")
+					re, err := regexp.Compile(regex_pattern)
+					if err != nil {
+						return parent_name
+					}
+					
+					substrings := re.FindStringSubmatch(parent_name)
+					if len(substrings) > 1 {
+						return substrings[1]
+					} 
+				}
+			}
+			return parent_name
+		})
+		// append ext
+		new_name = fmt.Sprintf("%s%s", new_name, filepath.Ext(file))
+
+	} else {
+		new_name = fmt.Sprintf("S%0*dE%0*d %s%s",
+							season_pad, season_num, 
+							ep_pad, ep_num,
+							title, filepath.Ext(file))
+	}
+
+	return new_name, nil
 }

--- a/rename.go
+++ b/rename.go
@@ -213,6 +213,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 
 func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {
 	var new_name string
+	ns, _ := naming_scheme.get()
 	if naming_scheme.is_some() {
 		scheme, err := naming_scheme.get()
 		if err != nil {
@@ -320,7 +321,7 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 		// append ext
 		new_name = filepath.Join(filepath.Dir(abs_path), fmt.Sprintf("%s%s", new_name, filepath.Ext(abs_path)))
 
-	} else {
+	} else if naming_scheme.is_none() || ns == "default"{
 		new_name = fmt.Sprintf("S%0*dE%0*d %s%s",
 							season_pad, season_num, 
 							ep_pad, ep_num,

--- a/rename.go
+++ b/rename.go
@@ -51,20 +51,20 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		season_path := filepath.Clean(info.path + "/" + season)
-
 		fmt.Println("path: ", season_path)
-		files, err := os.ReadDir(season_path)
+
+		var media_files []string
+		err := filepath.WalkDir(season_path, func(path string, d os.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if !d.IsDir() && is_media_file(d.Name()) {
+				media_files = append(media_files, path)
+			}
+			return nil
+		})
 		if err != nil {
 			return err
-		}
-		media_files := make([]string, 0)
-		for _, file := range files {
-			if file.IsDir() {
-				continue
-			}
-			if is_media_file(file.Name()) {
-				media_files = append(media_files, file.Name())
-			}
 		}
 		sort.Sort(FilenameSort(media_files))
 
@@ -124,17 +124,17 @@ func (info *SeriesInfo) rename() error {
 			}
 
 			fmt.Println(fmt.Sprintf("%-*s", 20, file), " --> ", fmt.Sprintf("%*s", 20, new_name))
-			fmt.Println("old", season_path+"/"+file, "new", season_path+"/"+new_name)
-			_, err = os.Stat(season_path+new_name)
+			fmt.Println("old", file, "\nnew", new_name)
+			_, err = os.Stat(new_name)
 			if err == nil {
-				fmt.Println("renaming", season_path+"/"+file, "to", season_path+"/"+new_name + " failed: file already exists")
+				fmt.Println("renaming", filepath.Base(file), "to", filepath.Base(new_name) + " failed: file already exists")
 				continue
 			} else if os.IsNotExist(err) {
-				err = os.Rename(season_path+"/"+file, season_path+"/"+new_name)
+				err = os.Rename(file, new_name)
+				if err != nil {
+					return err
+				}
 			} else {
-				return err
-			}
-			if err != nil {
 				return err
 			}
 		}
@@ -208,7 +208,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 	return title
 }
 
-func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, file string) (string, error) {
+func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {
 	var new_name string
 	if naming_scheme.is_some() {
 		scheme, err := naming_scheme.get()
@@ -220,10 +220,7 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 			// <season_num: \d+>
 			if strings.Contains(match, ":") {
 				pad := regexp.MustCompile(`\d+`).FindString(match)
-				pad_num, err := strconv.Atoi(pad)
-				if err != nil {
-					return match
-				}
+				pad_num, _ := strconv.Atoi(pad)
 				return fmt.Sprintf("%0*d", pad_num, season_num)
 			}
 			// <season_num>
@@ -234,79 +231,97 @@ func generate_new_name(naming_scheme Option[string], season_pad int, season_num 
 			// <episode_num: \d+>
 			if strings.Contains(match, ":") {
 				pad := regexp.MustCompile(`\d+`).FindString(match)
-				pad_num, err := strconv.Atoi(pad)
-				if err != nil {
-					return match
-				}
+				pad_num, _ := strconv.Atoi(pad)
 				return fmt.Sprintf("%0*d", pad_num, ep_num)
 			}
 			// <episode_num>
 			return fmt.Sprintf("%0*d", ep_pad, ep_num)
 		})
-		// replace <self: start,end> with filepath.Base(file)[start:end]
+		// replace <self>
 		new_name = regexp.MustCompile(`<self\s*:\s*\d+,\d+>`).ReplaceAllStringFunc(new_name, func(match string) string {
+			// if error, return full base name without extension
+			base_name := filepath.Base(abs_path)
+			base_name = strings.ReplaceAll(base_name, filepath.Ext(base_name), "")
+
 			parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
 			if len(parts) != 2 {
-				return match
+				return base_name
 			}
 			start, err := strconv.Atoi(parts[0])
-			if err != nil {
-				return match
+			if err != nil || start >= len(base_name) {
+				return base_name
 			}
 			end, err := strconv.Atoi(parts[1])
-			if err != nil {
-				return match
+			if err != nil || end+1 >= len(base_name) {
+				return base_name
 			}
-			fmt.Println(filepath.Base(file)[start:end])
-			return filepath.Base(file)[start:end]
+			return base_name[start:end+1]
 		})
 		// replace <parent> tokens with nth parent's name
 		// lol goodluck: https://regex-vis.com/?r=%3C%28parent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%7Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%2B%5Cs*%2C%5Cs*%5Cd%2B%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%29%5Cs*%3E&e=0
-		new_name = regexp.MustCompile(`<(parent(-parent)*(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?|p(-\d+)?(\s*:\s*((\d+\s*,\s*\d+)|('[^']*')))?)\s*>`).ReplaceAllStringFunc(new_name, func(match string) string {
+		new_name = regexp.MustCompile(`<(parent(-parent)*(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?|p(-\d+)?(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?)\s*>`).ReplaceAllStringFunc(new_name, func(match string) string {
 			n, err := parent_token_to_int(match)
 			if err != nil {
-				return match
+				return new_name
 			}
-			parent_name := nth_parent(file, n)
+			parent_name := nth_parent(abs_path, n)
 
-			if strings.Contains(match, ":") {
-				parts := regexp.MustCompile(`\d+`).FindAllString(match, 2)
+			// <parent>
+			if !strings.Contains(match, ":") {return parent_name}
 
-				if len(parts) == 2 {
-					start, err := strconv.Atoi(parts[0])
-					if err != nil {
-						return parent_name
-					}
-					end, err := strconv.Atoi(parts[1])
-					if err != nil {
-						return parent_name
-					}
-					return parent_name[start:end]
+			// has ':'
+			// <parent: <value>>
+			trimmed_match := strings.Trim(match, "<>")
+			val := strings.TrimSpace(strings.SplitN(trimmed_match, ":", 2)[1])
+			switch val[0] {
+			// <parent: 1,2>
+			case ',':
+				val := strings.SplitN(val, ",", 2)
+				start, err := strconv.Atoi(val[0])
+				if err != nil || start >= len(parent_name) {
+					return parent_name
 				}
-				regex_pattern := regexp.MustCompile(`'[^']*'`).FindString(match)
-				if len(regex_pattern) > 0 {
-					regex_pattern = strings.Trim(regex_pattern, "'")
-					re, err := regexp.Compile(regex_pattern)
-					if err != nil {
-						return parent_name
-					}
-					
-					substrings := re.FindStringSubmatch(parent_name)
-					if len(substrings) > 1 {
-						return substrings[1]
-					} 
+				end, err := strconv.Atoi(val[1])
+				if err != nil || end+1 >= len(parent_name) {
+					return parent_name
 				}
+				return parent_name[start:end+1]
+
+			// <parent: '<regex_pattern>'>
+			case '\'':
+				regex_pattern := strings.Trim(val, "'")
+				_, err := regexp.Compile(regex_pattern)
+				if err != nil {
+					return parent_name
+				}
+				sub_regexes := split_regex_by_pipe(regex_pattern)
+				for _, re := range sub_regexes {
+					sub_match := regexp.MustCompile(re).FindStringSubmatch(parent_name)
+					if len(sub_match) > 1 {
+						// found a substring match
+						return sub_match[1]
+					}
+				}
+				// did not find a substring match
+				return parent_name
+
+			// <parent: 1>
+			default:
+				start, err := strconv.Atoi(val)
+				if err != nil || start+1 >= len(parent_name) {
+					return parent_name
+				}
+				return parent_name[start:start+1]
 			}
-			return parent_name
 		})
 		// append ext
-		new_name = fmt.Sprintf("%s%s", new_name, filepath.Ext(file))
+		new_name = filepath.Join(filepath.Dir(abs_path), fmt.Sprintf("%s%s", new_name, filepath.Ext(abs_path)))
 
 	} else {
 		new_name = fmt.Sprintf("S%0*dE%0*d %s%s",
 							season_pad, season_num, 
 							ep_pad, ep_num,
-							title, filepath.Ext(file))
+							title, filepath.Ext(abs_path))
 	}
 
 	return new_name, nil

--- a/rename.go
+++ b/rename.go
@@ -208,7 +208,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 	} else if series_type == "named_seasons" {
 		title = filepath.Base(path) + " " + filepath.Base(season_path)
 	}
-	return title
+	return clean_title(title)
 }
 
 func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {

--- a/rename.go
+++ b/rename.go
@@ -19,6 +19,7 @@ type SeriesInfo struct {
 	movies          []string
 	keep_ep_nums    Option[bool]
 	starting_ep_num Option[int]
+	naming_scheme   Option[string]
 }
 
 type MovieInfo struct {

--- a/rename.go
+++ b/rename.go
@@ -19,9 +19,7 @@ type SeriesInfo struct {
 	series_type     string
 	seasons         map[int]string
 	movies          []string
-	keep_ep_nums    Option[bool]
-	starting_ep_num Option[int]
-	naming_scheme   Option[string]
+	options         AdditionalOptions
 }
 
 type MovieInfo struct {
@@ -74,12 +72,11 @@ func (info *SeriesInfo) rename() error {
 		}
 		
 		// if additional options are none aka user inputted var, ask for user input
-		season_ken, season_sen, season_s0, season_ns := info.keep_ep_nums, info.starting_ep_num, some[bool](false), info.naming_scheme
-		prompt_additional_options(&season_ken, &season_sen, &season_s0, &season_ns, season_path)
+		season_options := prompt_additional_options(info.options, season_path)
 
 		var ep_num, sen int
-		if season_sen.is_some() {
-			sen, _ = season_sen.get()
+		if season_options.starting_ep_num.is_some() {
+			sen, _ = season_options.starting_ep_num.get()
 		} else {
 			sen = 1
 		}
@@ -91,8 +88,8 @@ func (info *SeriesInfo) rename() error {
 
 		ep_nums := make([]int, 0)
 		var ken bool
-		if season_ken.is_some() {
-			ken, _ = season_ken.get()
+		if season_options.keep_ep_nums.is_some() {
+			ken, _ = season_options.keep_ep_nums.get()
 		} else {
 			ken = false
 		}
@@ -120,11 +117,11 @@ func (info *SeriesInfo) rename() error {
 		}
 
 		for i, file := range media_files {
-			title := default_title(info.series_type, season_ns, info.path, season_path)
-			new_name, err := generate_new_name(season_ns,				// naming_scheme
-										  max_season_digits, num, 		// season_pad, season_num
-										  max_ep_digits, ep_nums[i],	// ep_pad, ep_num 
-										  title, file) 					// title, file path
+			title := default_title(info.series_type, season_options.naming_scheme, info.path, season_path)
+			new_name, err := generate_new_name(season_options.naming_scheme,// naming_scheme
+											   max_season_digits, num, 		// season_pad, season_num
+										  	   max_ep_digits, ep_nums[i],	// ep_pad, ep_num 
+										  	   title, file)					// title, file path
 			if err != nil {
 				return err
 			}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -55,6 +55,10 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 }
 
 func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Option[int], has_season_0 *Option[bool], naming_scheme *Option[string], path string) {
+	default_ken := some[bool](false)
+	default_sen := some[int](1)
+	default_s0 := some[bool](false)
+
 	// prompt user for additional options
 	if (*keep_ep_nums).is_none() {
 		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\ninputs: (y/n/var/default/exit)")
@@ -68,8 +72,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					(*keep_ep_nums) = some[bool](true)
 				case "n", "no":
 					(*keep_ep_nums) = some[bool](false)
-				case "var", "default":
+				case "var", "exit":
 					break
+				case "default":
+					(*keep_ep_nums) = default_ken
 				default:
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
 					continue
@@ -91,7 +97,9 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				}
 
 				switch input {
-				case "var", "default", "exit":
+				case "default":
+					(*starting_ep_num) = default_sen
+				case "var", "exit":
 					break
 				default:
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
@@ -112,8 +120,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					(*has_season_0) = some[bool](true)
 				case "n", "no":
 					(*has_season_0) = some[bool](false)
-				case "var", "default", "exit":
+				case "var", "exit":
 					break
+				case "default":
+					(*has_season_0) = default_s0
 				default:
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
 					continue

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -67,18 +67,19 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 			if scanner.Scan() {
 				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
 
-				switch input {
-				case "y", "yes":
+				if input == "y" || input == "yes" {
 					(*keep_ep_nums) = some[bool](true)
-				case "n", "no":
-					(*keep_ep_nums) = some[bool](false)
-				case "var", "exit":
 					break
-				case "default":
+				} else if input == "n" || input == "no" {
+					(*keep_ep_nums) = some[bool](false)
+					break
+				} else if input == "var" || input == "exit" {
+					break
+				} else if input == "default" {
 					(*keep_ep_nums) = default_ken
-				default:
-					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
-					continue
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'exit', or 'default'")
 				}
 			}
 		}
@@ -95,15 +96,13 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					(*starting_ep_num) = some[int](int_input)
 					break
 				}
-
-				switch input {
-				case "default":
+				if input == "default" {
 					(*starting_ep_num) = default_sen
-				case "var", "exit":
 					break
-				default:
-					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
-					continue
+				} else if input == "var" || input == "exit" {
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter '<int>', 'var', 'exit', or 'default'")
 				}
 			}
 		}
@@ -115,18 +114,19 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 			if scanner.Scan() {
 				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
 
-				switch input {
-				case "y", "yes":
+				if input == "y" || input == "yes" {
 					(*has_season_0) = some[bool](true)
-				case "n", "no":
-					(*has_season_0) = some[bool](false)
-				case "var", "exit":
 					break
-				case "default":
+				} else if input == "n" || input == "no" {
+					(*has_season_0) = some[bool](false)
+					break
+				} else if input == "var" || input == "exit" {
+					break
+				} else if input == "default" {
 					(*has_season_0) = default_s0
-				default:
-					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
-					continue
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'exit', or 'default'")
 				}
 			}
 		}
@@ -146,7 +146,6 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 					break
 				} else {
 					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'default', 'exit', or a valid naming scheme\ninput:", input, "\nerror:", err)
-					continue
 				}
 			}
 		}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -8,7 +8,7 @@ import (
 	"strconv"
 )
 
-func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool]) (SeriesInfo, error) {
+func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool], naming_scheme Option[string]) (SeriesInfo, error) {
 	// get prerequsite info for renaming series
 	info := SeriesInfo{
 		path: 				path,

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -56,6 +56,7 @@ func prompt_additional_options(options AdditionalOptions, path string) (Addition
 	default_ken := some[bool](false)
 	default_sen := some[int](1)
 	default_s0 := some[bool](false)
+	default_ns := some[string]("default")
 
 	// prompt user for additional options
 	if options.keep_ep_nums.is_none() {
@@ -135,7 +136,8 @@ func prompt_additional_options(options AdditionalOptions, path string) (Addition
 			}
 		}
 	}
-	if options.naming_scheme.is_none() {
+	naming_scheme, _ := options.naming_scheme.get()
+	if options.naming_scheme.is_none() || naming_scheme != "default" {
 		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\ninputs: (<naming scheme>/var/default)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
@@ -143,8 +145,10 @@ func prompt_additional_options(options AdditionalOptions, path string) (Addition
 				input := scanner.Text()
 				input = strings.TrimSpace(input)
 
-				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" {
+				if strings.ToLower(input) == "var" {
 					break
+				} else if input == "default" {
+					options.naming_scheme = default_ns
 				} else if input == "exit" {
 					return options
 				} else if err := validate_naming_scheme(input); err == nil {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -57,7 +57,7 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Option[int], has_season_0 *Option[bool], naming_scheme *Option[string], path string) {
 	// prompt user for additional options
 	if (*keep_ep_nums).is_none() {
-		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\ninputs: (y/n/var/default/exit)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {
@@ -78,7 +78,7 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 		}
 	}
 	if (*starting_ep_num).is_none() {
-		fmt.Println("[INPUT]\nstarting episode number for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<int>/var/default/exit)")
+		fmt.Println("[INPUT]\nstarting episode number for", filepath.Base(path), "?\ninputs: (<int>/var/default/exit)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {
@@ -101,7 +101,7 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 		}
 	}
 	if (*has_season_0).is_none() {
-		fmt.Println("[INPUT]\nis the specials/extras directory under", filepath.Base(path), "season 0?\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		fmt.Println("[INPUT]\nspecials/extras directory under", filepath.Base(path), "as season 0?", "\ninputs: (y/n/var/default/exit)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {
@@ -122,7 +122,7 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 		}
 	}
 	if (*naming_scheme).is_none() {
-		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<naming scheme>/var/default)")
+		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\ninputs: (<naming scheme>/var/default)")
 		for {
 			scanner := bufio.NewScanner(os.Stdin)
 			if scanner.Scan() {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -1,24 +1,17 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool], starting_ep_num Option[int], has_season_0 Option[bool], naming_scheme Option[string]) (SeriesInfo, error) {
 	// get prerequsite info for renaming series
-	info := SeriesInfo{
-		path: 				path,
-		series_type: 		s_type,
-		seasons: 			make(map[int]string),
-		movies: 			make([]string, 0),
-		keep_ep_nums: 		keep_ep_nums,
-		starting_ep_num: 	starting_ep_num,
-	}
-
 	is_valid_type := map[string]bool{
 		"single_season_no_movies": true,
 		"single_season_with_movies": true,
@@ -29,11 +22,24 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 	if !is_valid_type[s_type] {
 		return SeriesInfo{}, fmt.Errorf("unknown series type: %s", s_type)
 	}
+
+	// if additional options are none aka user inputted var, ask for user input
+	prompt_additional_options(&keep_ep_nums, &starting_ep_num, &has_season_0, &naming_scheme, path)
+	info := SeriesInfo{
+		path: 				path,
+		series_type: 		s_type,
+		seasons: 			make(map[int]string),
+		movies: 			make([]string, 0),
+		keep_ep_nums: 		keep_ep_nums,
+		starting_ep_num: 	starting_ep_num,
+		naming_scheme: 		naming_scheme,
+	}
+
 	s0, err := has_season_0.get()
 	if err != nil {
 		return SeriesInfo{}, err
 	}
-	seasons, movies, err := get_series_content(path, s_type, s0)
+	seasons, movies, err := fetch_series_content(path, s_type, s0)
 	if err != nil {
 		return SeriesInfo{}, err
 	}
@@ -48,7 +54,96 @@ func series_rename_prereqs(path string, s_type string, keep_ep_nums Option[bool]
 	return info, nil
 }
 
-func get_series_content (path string, s_type string, has_season_0 bool) (map[int]string, []string, error) {
+func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Option[int], has_season_0 *Option[bool], naming_scheme *Option[string], path string) {
+	// prompt user for additional options
+	if (*keep_ep_nums).is_none() {
+		fmt.Println("[INPUT]\nkeep episode numbers for", filepath.Base(path), "?", "\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+				switch input {
+				case "y", "yes":
+					(*keep_ep_nums) = some[bool](true)
+				case "n", "no":
+					(*keep_ep_nums) = some[bool](false)
+				case "var", "default":
+					break
+				default:
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
+					continue
+				}
+			}
+		}
+	}
+	if (*starting_ep_num).is_none() {
+		fmt.Println("[INPUT]\nstarting episode number for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<int>/var/default/exit)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+				int_input, err := strconv.Atoi(input)
+				if err == nil {
+					(*starting_ep_num) = some[int](int_input)
+					break
+				}
+
+				switch input {
+				case "var", "default", "exit":
+					break
+				default:
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
+					continue
+				}
+			}
+		}
+	}
+	if (*has_season_0).is_none() {
+		fmt.Println("[INPUT]\nis the specials/extras directory under", filepath.Base(path), "season 0?\nfull path: ", path, "\ninputs: (y/n/var/default/exit)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := strings.ToLower(strings.TrimSpace(scanner.Text()))
+
+				switch input {
+				case "y", "yes":
+					(*has_season_0) = some[bool](true)
+				case "n", "no":
+					(*has_season_0) = some[bool](false)
+				case "var", "default", "exit":
+					break
+				default:
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', or 'default'")
+					continue
+				}
+			}
+		}
+	}
+	if (*naming_scheme).is_none() {
+		fmt.Println("[INPUT]\nnaming scheme for", filepath.Base(path), "\nfull path: ", path, "\ninputs: (<naming scheme>/var/default)")
+		for {
+			scanner := bufio.NewScanner(os.Stdin)
+			if scanner.Scan() {
+				input := scanner.Text()
+				input = strings.TrimSpace(input)
+
+				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" || strings.ToLower(input) == "exit" {
+					break
+				} else if err := validate_naming_scheme(input); err == nil {
+					(*naming_scheme) = some[string](input)
+					break
+				} else {
+					fmt.Println("[ERROR]\ninvalid input, please enter 'y', 'n', 'default', 'exit', or a valid naming scheme\ninput:", input, "\nerror:", err)
+					continue
+				}
+			}
+		}
+	}
+}
+
+func fetch_series_content(path string, s_type string, has_season_0 bool) (map[int]string, []string, error) {
 	seasons := make(map[int]string)
 	movies := make([]string, 0)
 	
@@ -128,7 +223,7 @@ func get_series_content (path string, s_type string, has_season_0 bool) (map[int
 	return seasons, movies, nil
 }
 
-func movie_rename_prereqs (path string, m_type string) (MovieInfo, error) {
+func movie_rename_prereqs(path string, m_type string) (MovieInfo, error) {
 	info := MovieInfo{
 		path: 			path,
 		movie_type: 	m_type,

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -73,8 +73,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				} else if input == "n" || input == "no" {
 					(*keep_ep_nums) = some[bool](false)
 					break
-				} else if input == "var" || input == "exit" {
+				} else if input == "var" {
 					break
+				} else if input == "exit" {
+					return
 				} else if input == "default" {
 					(*keep_ep_nums) = default_ken
 					break
@@ -99,8 +101,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				if input == "default" {
 					(*starting_ep_num) = default_sen
 					break
-				} else if input == "var" || input == "exit" {
+				} else if input == "var" {
 					break
+				} else if input == "exit" {
+					return
 				} else {
 					fmt.Println("[ERROR]\ninvalid input, please enter '<int>', 'var', 'exit', or 'default'")
 				}
@@ -120,8 +124,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				} else if input == "n" || input == "no" {
 					(*has_season_0) = some[bool](false)
 					break
-				} else if input == "var" || input == "exit" {
+				} else if input == "var" {
 					break
+				} else if input == "exit" {
+					return					
 				} else if input == "default" {
 					(*has_season_0) = default_s0
 					break
@@ -139,8 +145,10 @@ func prompt_additional_options(keep_ep_nums *Option[bool], starting_ep_num *Opti
 				input := scanner.Text()
 				input = strings.TrimSpace(input)
 
-				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" || strings.ToLower(input) == "exit" {
+				if strings.ToLower(input) == "var" || strings.ToLower(input) == "default" {
 					break
+				} else if input == "exit" {
+					return
 				} else if err := validate_naming_scheme(input); err == nil {
 					(*naming_scheme) = some[string](input)
 					break

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -173,7 +173,7 @@ func fetch_series_content(path string, s_type string, has_season_0 bool) (map[in
 		return nil, nil, err
 	}
 
-	extras_pattern := regexp.MustCompile(`^(?i)specials?|extras?|trailers?|ova`)
+	extras_pattern := regexp.MustCompile(`^(?i)(specials?|extras?|o(v|n)a)`)
 	for _, subdir := range subdirs {
 		if !subdir.IsDir() {
 			continue

--- a/utils.go
+++ b/utils.go
@@ -208,3 +208,41 @@ func has_only_one_match_group (s string) bool {
 
 	return matchGroupCount == 1
 }
+
+func parent_token_to_int(s string) (int, error) {
+	// lmao https://regex-vis.com/?r=%3Cparent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd+%5Cs*%2C%5Cs*%5Cd+%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
+	long_form := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d \s*,\s*\d )|('[^']*')))?\s*>`)
+	// lul https://regex-vis.com/?r=%3Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%5Cs*%2C%5Cs*%5Cd%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
+	short_form := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d\s*,\s*\d)|('[^']*')))?\s*>`)
+	
+	if long_form.MatchString(s) {
+		return strings.Count(s, "parent"), nil
+		
+	} else if short_form.MatchString(s) {
+		// only p
+		single_p := regexp.MustCompile(`p\s*:`)
+		if single_p.MatchString(s) {
+			return 1, nil
+		}
+		// p-int
+		match_num := regexp.MustCompile(`p-(\d+)`).FindStringSubmatch(s)
+		if len(match_num) != 2 {
+			return 0, fmt.Errorf("invalid parent token: %s", s)
+		}
+		num, err := strconv.Atoi(match_num[1])
+		if err != nil {
+			return 0, err
+		}
+		return num, nil
+
+	} else {
+		return 0, fmt.Errorf("invalid parent token: %s", s)
+	}
+}
+
+func nth_parent(path string, n int) string {
+	for i := 0; i < n; i++ {
+		path = filepath.Dir(path)
+	}
+	return filepath.Base(path)
+}

--- a/utils.go
+++ b/utils.go
@@ -169,7 +169,7 @@ func clean_title (title string) string {
 	return title
 }
 
-func split_regex_by_pipe (s string) []string {
+func split_regex_by_pipe(s string) []string {
 	var parts []string
 	depth := 0
 	part_start := 0
@@ -211,9 +211,9 @@ func has_only_one_match_group (s string) bool {
 
 func parent_token_to_int(s string) (int, error) {
 	// lmao https://regex-vis.com/?r=%3Cparent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd+%5Cs*%2C%5Cs*%5Cd+%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
-	long_form := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d \s*,\s*\d )|('[^']*')))?\s*>`)
+	long_form := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?\s*>`)
 	// lul https://regex-vis.com/?r=%3Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%5Cs*%2C%5Cs*%5Cd%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
-	short_form := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d\s*,\s*\d)|('[^']*')))?\s*>`)
+	short_form := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?\s*>`)
 	
 	if long_form.MatchString(s) {
 		return strings.Count(s, "parent"), nil

--- a/utils.go
+++ b/utils.go
@@ -220,7 +220,7 @@ func parent_token_to_int(s string) (int, error) {
 		
 	} else if short_form.MatchString(s) {
 		// only p
-		single_p := regexp.MustCompile(`p\s*:`)
+		single_p := regexp.MustCompile(`p\s*[^-]:?`)
 		if single_p.MatchString(s) {
 			return 1, nil
 		}


### PR DESCRIPTION
## v0.3.0: naming schemes, prompt for optional flags if var is selected, readme overhaul
### biggest change is naming schemes
This version fully implements the naming schemes, from reading, parsing, and using it to rename. For more information on the implementation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)

### value 'var' now prompts the user for input
By default, if the flag is ommitted, its value is populated with its respective default value

Now, when user inputs a flag, that can have a value of `var`, with `var`, it assigns nothing to that flag. Since there is no value, the user will be prompted for input at:
- per series type level

if input on per series type level is also `var`, prompt user at:
- per series entry level

if input on per series entry level is also `var`, prompt user at:
- per series season level
- note: `--has-season-0` is exempted here since this flag does not allow `var` as input on a *per series entry level*

### README overhaul + addition of wiki
Moved most of the README to the [wiki page](https://github.com/saltkid/gorn/wiki). The README is simplified with links to the wiki
___
### other changes
1. addition of `--help` and `--version` flags
2. in naming scheme, for apis that take a range of two numbers, it can now take a single number to represent a single character