### PR TITLE
Feat/prompt validation

### DIFF
--- a/help.go
+++ b/help.go
@@ -172,7 +172,7 @@ func help_s0(verbose bool) {
 }
 
 func help_ns(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme>/default",
+	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme>/default/var",
 			"Change the naming scheme\n")
 	if verbose {
 		fmt.Println("\n  examples: gorn -ns default")

--- a/main.go
+++ b/main.go
@@ -15,9 +15,10 @@ func main() {
 	}
 
 	args, err := parse_args(os.Args[1:])
-	if err != nil && err.Error() != "safe exit" {
-		panic(err)
-	} else if err.Error() == "safe exit" {
+	if err != nil {
+		if err.Error() != "safe exit" {
+			panic(err)
+		}
 		return
 	}
 
@@ -112,7 +113,7 @@ func main() {
 	}
 
 	fmt.Println("test for named seasons")
-	named_season_options := prompt_additional_options(args.options, "all named seasons")
+	named_season_options := prompt_additional_options(args.options, "all named seasons", 0)
 	for _, v := range series.named_seasons {
 		info, err := series_rename_prereqs(v, "named_seasons", named_season_options)
 		if err != nil {
@@ -128,7 +129,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season no movies")
-	ssnm_options := prompt_additional_options(args.options, "all single season with no movies")
+	ssnm_options := prompt_additional_options(args.options, "all single season with no movies", 0)
 	for _, v := range series.single_season_no_movies {
 		info, err := series_rename_prereqs(v, "single_season_no_movies", ssnm_options)
 		if err != nil {
@@ -144,7 +145,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for single season with movies")
-	sswm_options := prompt_additional_options(args.options, "all single season with movies")
+	sswm_options := prompt_additional_options(args.options, "all single season with movies", 0)
 	for _, v := range series.single_season_with_movies {
 		info, err := series_rename_prereqs(v, "single_season_with_movies", sswm_options)
 		if err != nil {
@@ -160,7 +161,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season no movies")
-	msnm_options := prompt_additional_options(args.options, "all multiple season with no movies")
+	msnm_options := prompt_additional_options(args.options, "all multiple season with no movies", 0)
 	for _, v := range series.multiple_season_no_movies {
 		info, err := series_rename_prereqs(v, "multiple_season_no_movies", msnm_options)
 		if err != nil {
@@ -176,7 +177,7 @@ func main() {
 	fmt.Println()
 
 	fmt.Println("test for multiple season with movies")
-	mswm_options := prompt_additional_options(args.options, "all multiple season with movies")
+	mswm_options := prompt_additional_options(args.options, "all multiple season with movies", 0)
 	for _, v := range series.multiple_season_with_movies {
 		info, err := series_rename_prereqs(v, "multiple_season_with_movies", mswm_options)
 		if err != nil {

--- a/rename.go
+++ b/rename.go
@@ -72,7 +72,7 @@ func (info *SeriesInfo) rename() error {
 		}
 		
 		// if additional options are none aka user inputted var, ask for user input
-		season_options := prompt_additional_options(info.options, season_path)
+		season_options := prompt_additional_options(info.options, season_path, 2)
 
 		var ep_num, sen int
 		if season_options.starting_ep_num.is_some() {
@@ -214,7 +214,7 @@ func default_title(series_type string, naming_scheme Option[string], path string
 func generate_new_name(naming_scheme Option[string], season_pad int, season_num int, ep_pad int, ep_num int, title string, abs_path string) (string, error) {
 	var new_name string
 	ns, _ := naming_scheme.get()
-	if naming_scheme.is_some() {
+	if naming_scheme.is_some() && ns != "default" {
 		scheme, err := naming_scheme.get()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
### changes
1. prompt var differently when:
    1. per series type
        - all prompts can accept `var`
    2. per series entry
        - all prompts except `--has-season-0` can accept `var`
    3. per series entry season
        - no prompts can accept `var`
2. update wiki to accommodate this change