### PR TITLE
Chore/remove all arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,13 @@ These are the additional options that can be passed to the cli. For a more detai
 3. `--options | -o`
     - **values:** none
 4. `--keep-ep-num | -ken`
-    - **values:** `all yes/no/default` or `var`
+    - **values:** `yes | no | default | var`
 5. `--starting-ep-num | -sen`
-    - **values:** `all <num>/default` or `var`
+    - **values:** `<num> | default | var`
 6. `--has-season-0 | -s0`
-    - **values:** `all yes/no/default` or `var`
+    - **values:** `yes | no | default | var`
 7. `--naming-scheme | -ns`
-    - **values:** `all "<scheme>"/default` or `var`
+    - **values:** `"<scheme>"| default | var`
 
 ### [*scheme*](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)
 scheme can be composed of any character (as long as its a valid filename) and/or APIs enclosed in <> like:

--- a/help.go
+++ b/help.go
@@ -125,7 +125,7 @@ func HelpMovies(verbose bool) {
 }
 
 func HelpKEN(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--keep-ep-num | -ken] <all yes/no/default | var>",
+	fmt.Printf("%-60s%s", "  [--keep-ep-num | -ken] yes | no | default | var>",
 		"Keep original episode numbers in filename based on common naming patterns\n\n")
 	if verbose {
 		fmt.Println("  common naming patterns taken into account are:")
@@ -136,28 +136,28 @@ func HelpKEN(verbose bool) {
 		fmt.Println("  NOTE: This is not how the default naming scheme looks like in gorn. These common naming cases are just here to read the episode number from the filename.")
 		fmt.Println("        second number is episode")
 		fmt.Println("        if no common naming pattern is found, the file will not be renamed.")
-		fmt.Println("\n  examples: gorn -ken all yes")
-		fmt.Println("            gorn -ken all no")
-		fmt.Println("            gorn -ken all default")
+		fmt.Println("\n  examples: gorn -ken yes")
+		fmt.Println("            gorn -ken no")
+		fmt.Println("            gorn -ken default")
 		fmt.Println("            gorn -ken var")
 	}
 }
 
 func HelpSEN(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--starting-ep-num | -sen] <all int/default | var>",
+	fmt.Printf("%-60s%s", "  [--starting-ep-num | -sen] <int> | default | var>",
 		"Set the starting episode number in renaming.\n")
 	if verbose {
 		fmt.Println("\n  This can be useful if episodes are in absolute order but in different season directories for separation")
 		fmt.Println("  User can specify different starting episode number for each of those seasons")
-		fmt.Println("\n  examples: gorn -sen all 1")
-		fmt.Println("            gorn -sen all 25")
-		fmt.Println("            gorn -sen all default")
+		fmt.Println("\n  examples: gorn -sen 1")
+		fmt.Println("            gorn -sen 25")
+		fmt.Println("            gorn -sen default")
 		fmt.Println("            gorn -sen var")
 	}
 }
 
 func HelpS0(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--has-season-0 | -s0] <all yes/no/default | var>",
+	fmt.Printf("%-60s%s", "  [--has-season-0 | -s0] yes | no | default | var>",
 		"Treat extras/specials/OVA/etc directory as season 0\n")
 	if verbose {
 		fmt.Println("\n  Note that if this is set, there must be only one specials/extras/OVA directory under a series entry")
@@ -165,15 +165,15 @@ func HelpS0(verbose bool) {
 		fmt.Println("  'gorn -r path/to/root -s0 var'")
 		fmt.Println("  This will let gorn prompt the user at: per series type level and per series entry level")
 		fmt.Println("  if var is inputted at the per series type level, it will prompt the user at per series entry level which is where this flag will be most useful")
-		fmt.Println("\n  examples: gorn -s0 all yes")
-		fmt.Println("            gorn -s0 all no")
-		fmt.Println("            gorn -s0 all default")
+		fmt.Println("\n  examples: gorn -s0 yes")
+		fmt.Println("            gorn -s0 no")
+		fmt.Println("            gorn -s0 default")
 		fmt.Println("            gorn -s0 var")
 	}
 }
 
 func HelpNS(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme>/default/var",
+	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme> | default | var",
 		"Change the naming scheme\n")
 	if verbose {
 		fmt.Println("\n  examples: gorn -ns default")

--- a/main_test.go
+++ b/main_test.go
@@ -121,10 +121,10 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
 	}
 
-	command = []string{"-r", "./test_files", "-ken", "yes"}
+	command = []string{"-r", "./test_files", "-ken", "all", "yes"}
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'yes is not a valid arg. must be all or var'")
+		t.Errorf("expected error 'all is not a valid arg. must be yes no default or var'")
 	} else {
 		t.Log("-r", "./test_files", "-ken", "yes", "\n\t", err, "\n")
 	}
@@ -153,10 +153,10 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log("-r", "./test_files", "-sen", "all", "yes", "\n\t", err, "\n")
 	}
 
-	command = []string{"-r", "./test_files", "-sen", "1"}
+	command = []string{"-r", "./test_files", "-sen", "all", "1"}
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error '1 is not a valid arg. must be all or var'")
+		t.Errorf("expected error 'all is not a valid arg. must be int default or var'")
 	} else {
 		t.Log("-r", "./test_files", "-sen", "yes", "\n\t", err, "\n")
 	}
@@ -185,7 +185,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
 	}
 
-	command = []string{"-r", "./test_files", "--naming-scheme", "S01E01"}
+	command = []string{"-r", "./test_files", "-sen", "1", "--starting-ep-num", "2"}
 	_, err = ParseArgs(command)
 	if err == nil {
 		t.Errorf("expected error 'multiple starting-ep-num flags'")
@@ -194,12 +194,12 @@ func Test_ParseArgs(t *testing.T) {
 	}
 	t.Log("------------expects success------------")
 
-	command = []string{"--root", "./test_files", "-s0", "all", "yes"}
+	command = []string{"--root", "./test_files", "-s0", "yes"}
 	_, err = ParseArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
-		t.Log("--root", "./test_files", "-s0", "all", "yes")
+		t.Log("--root", "./test_files", "-s0", "yes")
 	}
 
 	command = []string{"--root", "./test_files"}

--- a/rename.go
+++ b/rename.go
@@ -116,6 +116,21 @@ func (info *SeriesInfo) Rename() error {
 			}
 		}
 
+		// adjust episode read episode numbers if starting episode number was specified by user
+		if seasonOptions.startingEpNum.IsSome() {
+			adjustVal := 0
+			minEpNum := epNums[0]
+			for _, val := range epNums[1:] {
+				if val < minEpNum {
+					minEpNum = val
+				}
+			}
+			adjustVal = sen - minEpNum
+			for i, val := range epNums {
+				epNums[i] = val + adjustVal
+			}
+		}
+
 		for i, file := range mediaFiles {
 			title := DefaultTitle(info.seriesType, seasonOptions.namingScheme, info.path, seasonPath)
 			newName, err := GenerateNewName(seasonOptions.namingScheme, // namingScheme


### PR DESCRIPTION
### changes
1. remove `all` as an arg value for all flags that previously accepted it
    - `all` was **always** followed by `yes` `no` and `default` anyway so I just removed it
2. if `--keep-ep-nums` flag is present/set to `yes`, and `--starting-ep-num` flag is set to a positive integer:
    1. read episode number in filenames
    2. adjust all read episode number to make: minimum value == `--starting-ep-num` value
    3. example:
        - read ep nums in filenames: `{3 5 7 9}`
        - `--starting-ep-num`: `1`
        - output: `{1 3 5 7}`
3. update wiki and readme
### new
none