### PR TITLE
Feat/rework commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,22 +72,24 @@ gorn --movies path/to/movies/subroot/dir
 ```
 gorn -r path/to/root/dir -s path/to/another/series/subroot/dir -m path/to/another/movies/subroot/dir
 ```
-___
-## [Optional Flags](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
-These are the additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
+## [Switches](https://github.com/saltkid/gorn/wiki/Usage#switches)
+Switches are flags that switch the behavior of **gorn** from its default behavior of renaming media files. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#switches)
 1. `--help | -h`
-    - **values:** `<other flags>`
+    - **values:** `<commands> | <switches> | <flags>`
 2. `--version | -v`
     - **values:** none
-3. `--options | -o`
-    - **values:** none
-4. `--keep-ep-num | -ken`
+## [Flags](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
+These are the additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
+
+1. `--keep-ep-num | -ken`
     - **values:** `yes | no | default | var`
-5. `--starting-ep-num | -sen`
+2. `--starting-ep-num | -sen`
     - **values:** `<num> | default | var`
-6. `--has-season-0 | -s0`
+3. `--has-season-0 | -s0`
     - **values:** `yes | no | default | var`
-7. `--naming-scheme | -ns`
+4. `--options | -o`
+    - **values:** none
+5. `--naming-scheme | -ns`
     - **values:** `"<scheme>"| default | var`
 
 ### [*scheme*](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@ ___
 1. [Overview](#overview)
 2. [Prerequisites](#prerequisites)
 3. [Usage](#usage)
-    1. [Optional Flags](#optional-flags)
+    1. [Switches](#switches)
+    2. [Flags](#flags)
 ___ 
 # [Overview](https://github.com/saltkid/gorn/wiki)
 Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.

--- a/help.go
+++ b/help.go
@@ -3,11 +3,15 @@ package main
 import "fmt"
 
 func WelcomeMsg(version string) {
-	fmt.Println("gorn - go rename tool")
-	fmt.Println("version:", version)
+	Version(version)
 	fmt.Println("renames series/movies media files based on directory naming and structure")
 	fmt.Println("for more usage information, run 'gorn -h'")
 	fmt.Println("https://github.com/saltkid/gorn")
+}
+
+func Version(version string) {
+	fmt.Println("gorn - go rename tool")
+	fmt.Println("version:", version)
 }
 
 func Help(flag string) {

--- a/help.go
+++ b/help.go
@@ -17,14 +17,22 @@ func Version(version string) {
 func Help(flag string) {
 	switch flag {
 	case "":
-		fmt.Println("Basic usage: gorn -r path/to/root")
-		fmt.Println("at least one of the three should be present: --root, --series, --movies")
-		fmt.Println("\nOptions:")
-		HelpHelp(false)
-		HelpVersion(false)
+		fmt.Println("Usage")
+		fmt.Println("\n  gorn root <path/to/root>")
+		fmt.Println("  gorn [command] <args> [--flags] <args>")
+		fmt.Println("  gorn [--switch] <args>")
+		fmt.Println("\nUse gorn -h [command] for more detailed help")
+		fmt.Println("            [switch]")
+		fmt.Println("            [flag]")
+
+		fmt.Println("\nCommands:")
 		HelpRoot(false)
 		HelpSeries(false)
 		HelpMovies(false)
+		fmt.Println("\nSwitches:")
+		HelpHelp(false)
+		HelpVersion(false)
+		fmt.Println("\nFlags:")
 		HelpKEN(false)
 		HelpSEN(false)
 		HelpS0(false)
@@ -33,11 +41,11 @@ func Help(flag string) {
 		HelpHelp(true)
 	case "-v", "--version":
 		HelpVersion(true)
-	case "-r", "--root":
+	case "root":
 		HelpRoot(true)
-	case "-s", "--series":
+	case "series":
 		HelpSeries(true)
-	case "-m", "--movies":
+	case "movies":
 		HelpMovies(true)
 	case "-ken", "--keep-ep-nums":
 		HelpKEN(true)
@@ -54,8 +62,9 @@ func Help(flag string) {
 }
 
 func HelpHelp(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--help | -h] <flag>",
-		"Show this help message if no flag is specified. Shows the specific help message if a flag is specified.\n")
+	fmt.Printf("%-60s%s", "  --help, -h",
+		"Show this help message if no arg is specified. Shows the specific help message of arg if specified.\n")
+	fmt.Println("    args: <command> | <switch> | <flag>")
 	if verbose {
 		fmt.Println("  example: gorn -h")
 		fmt.Println("  example: gorn -h --naming-scheme (this will give more specific help on the naming scheme flag)")
@@ -64,7 +73,7 @@ func HelpHelp(verbose bool) {
 }
 
 func HelpVersion(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--version | -v]",
+	fmt.Printf("%-60s%s", "  --version, -v",
 		"Show version\n")
 	if verbose {
 		fmt.Println("  example: gorn -v")
@@ -73,10 +82,10 @@ func HelpVersion(verbose bool) {
 }
 
 func HelpRoot(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--root | -r] path/to/root",
-		"Root directory containing series root and movie root\n\n")
+	fmt.Printf("%-60s%s", "  root <path/to/root>",
+		"Root directory containing series root and movie root\n")
 	if verbose {
-		fmt.Printf("  example: gorn -r /path/to/root\n\n")
+		fmt.Printf("\n  example: gorn root /path/to/root\n\n")
 		fmt.Println("  Root directory should contain series and movie roots where each root should contain series and movie entries respectively.")
 		fmt.Println("  example root directory:")
 		fmt.Println("  root")
@@ -91,10 +100,10 @@ func HelpRoot(verbose bool) {
 }
 
 func HelpSeries(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--series | -s] path/to/series/root",
-		"Series directory containing series entries\n\n")
+	fmt.Printf("%-60s%s", "  series <path/to/series/root>",
+		"Series directory containing series entries\n")
 	if verbose {
-		fmt.Println("  example: gorn -s /path/to/series/root")
+		fmt.Println("\n  example: gorn series /path/to/series/root")
 		fmt.Println("\n  Series directory should contain series entries.")
 		fmt.Println("  example series directory:")
 		fmt.Println("  series root")
@@ -110,10 +119,10 @@ func HelpSeries(verbose bool) {
 }
 
 func HelpMovies(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--movies | -m] path/to/movies/root",
-		"Movies directory containing movie entries\n\n")
+	fmt.Printf("%-60s%s", "  movies <path/to/movies/root>",
+		"Movies directory containing movie entries\n")
 	if verbose {
-		fmt.Println("  example: gorn -m /path/to/movies/root")
+		fmt.Println("\n  example: gorn movies /path/to/movies/root")
 		fmt.Println("\n  Movies directory should contain movie entries.")
 		fmt.Println("  example movies directory:")
 		fmt.Println("  movies root")
@@ -129,59 +138,63 @@ func HelpMovies(verbose bool) {
 }
 
 func HelpKEN(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--keep-ep-num | -ken] yes | no | default | var>",
-		"Keep original episode numbers in filename based on common naming patterns\n\n")
+	fmt.Printf("%-60s%s", "  --keep-ep-num, -ken",
+		"Keep original episode numbers in filename based on common naming patterns\n")
+	fmt.Println("    args: yes | no | default | var")
 	if verbose {
-		fmt.Println("  common naming patterns taken into account are:")
-		fmt.Println("    S01E02     |  S03.E04  | S05_E06 | S07-E08 | S09xE10 | S11 E12")
-		fmt.Println("    01.02      |   03_04   |  05-06  |  07x08  | 09 10 ")
-		fmt.Println("    Episode 01 | Episode02 |  EP03   |  EP-04  | E_05 | EP.06")
+		fmt.Println("\n  common naming patterns taken into account are:")
+		fmt.Println("    S01E02     | S03.E04   | S05_E06 | S07-E08 | S09xE10 | S11 E12")
+		fmt.Println("    01.02      | 03_04     | 05-06   | 07 x 08 | 09 10   | [11x12]")
+		fmt.Println("    Episode 01 | Episode02 | EP03    | EP-04   | E_05    | EP.06")
 		fmt.Println("\n  '.', '-', 'x', '_', and ' ' are valid season-episode separators.")
 		fmt.Println("  NOTE: This is not how the default naming scheme looks like in gorn. These common naming cases are just here to read the episode number from the filename.")
 		fmt.Println("        second number is episode")
 		fmt.Println("        if no common naming pattern is found, the file will not be renamed.")
-		fmt.Println("\n  examples: gorn -ken yes")
-		fmt.Println("            gorn -ken no")
-		fmt.Println("            gorn -ken default")
-		fmt.Println("            gorn -ken var")
+		fmt.Println("\n  examples: gorn -ken yes root /path/to/root")
+		fmt.Println("            gorn -ken no root /path/to/root")
+		fmt.Println("            gorn -ken default root /path/to/root")
+		fmt.Println("            gorn -ken var root /path/to/root")
 	}
 }
 
 func HelpSEN(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--starting-ep-num | -sen] <int> | default | var>",
+	fmt.Printf("%-60s%s", "  --starting-ep-num, -sen",
 		"Set the starting episode number in renaming.\n")
+	fmt.Println("    args: <int> | default | var")
 	if verbose {
 		fmt.Println("\n  This can be useful if episodes are in absolute order but in different season directories for separation")
 		fmt.Println("  User can specify different starting episode number for each of those seasons")
-		fmt.Println("\n  examples: gorn -sen 1")
-		fmt.Println("            gorn -sen 25")
-		fmt.Println("            gorn -sen default")
-		fmt.Println("            gorn -sen var")
+		fmt.Println("\n  examples: gorn -sen 1 root /path/to/root")
+		fmt.Println("            gorn -sen 25 root /path/to/root")
+		fmt.Println("            gorn -sen default root /path/to/root")
+		fmt.Println("            gorn -sen var root /path/to/root")
 	}
 }
 
 func HelpS0(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--has-season-0 | -s0] yes | no | default | var>",
+	fmt.Printf("%-60s%s", "  --has-season-0, -s0",
 		"Treat extras/specials/OVA/etc directory as season 0\n")
+	fmt.Println("    args: yes | no | default | var")
 	if verbose {
 		fmt.Println("\n  Note that if this is set, there must be only one specials/extras/OVA directory under a series entry")
 		fmt.Println("\n  This is more useful if specified at the series entry level by doing")
 		fmt.Println("  'gorn -r path/to/root -s0 var'")
 		fmt.Println("  This will let gorn prompt the user at: per series type level and per series entry level")
 		fmt.Println("  if var is inputted at the per series type level, it will prompt the user at per series entry level which is where this flag will be most useful")
-		fmt.Println("\n  examples: gorn -s0 yes")
-		fmt.Println("            gorn -s0 no")
-		fmt.Println("            gorn -s0 default")
-		fmt.Println("            gorn -s0 var")
+		fmt.Println("\n  examples: gorn -s0 yes root /path/to/root")
+		fmt.Println("            gorn -s0 no root /path/to/root")
+		fmt.Println("            gorn -s0 default root /path/to/root")
+		fmt.Println("            gorn -s0 var root /path/to/root")
 	}
 }
 
 func HelpNS(verbose bool) {
-	fmt.Printf("%-60s%s", "  [--naming-scheme | -ns] <naming-scheme> | default | var",
+	fmt.Printf("%-60s%s", "  --naming-scheme, -ns",
 		"Change the naming scheme\n")
+	fmt.Println("    args: <scheme> | default | var")
 	if verbose {
-		fmt.Println("\n  examples: gorn -ns default")
-		fmt.Println(`            gorn -ns "S<season_num>E<episode_num> <parent: 1,5> <parent-parent: '_(\d+)_'> <p-3: 2,5> [<self: '\.(\w+)$'>]"`)
+		fmt.Println("\n  examples: gorn -ns default root /path/to/root")
+		fmt.Println(`            gorn -ns "S<season_num>E<episode_num> <parent: 1,5> <parent-parent: '_(\d+)_'> <p-3: 2,5> [<self: '\.(\w+)$'>] root /path/to/root"`)
 		fmt.Println("\n  Naming Scheme APIs:")
 		fmt.Println("    1. <season_num>")
 		fmt.Println("       represents the season number which is based on series type, and directory structure and naming")

--- a/main.go
+++ b/main.go
@@ -15,7 +15,12 @@ func main() {
 		return
 	}
 
-	args, err := ParseArgs(os.Args[1:])
+	rawArgs, err := TokenizeArgs(os.Args[1:])
+	if err != nil {
+		panic(err)
+	}
+
+	args, err := ParseArgs(rawArgs)
 	if err != nil {
 		if err.Error() != "safe exit" {
 			panic(err)

--- a/main_test.go
+++ b/main_test.go
@@ -8,214 +8,723 @@ import (
 
 func Test_ParseArgs(t *testing.T) {
 	t.Log("------------expects errors------------")
-
-	command := []string{"--root", "--series", "--movies"}
+	
+	cmd := "root -s0 yes"
+	command := strings.Split(cmd, " ")
 	_, err := ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'missing root dir path'")
+		t.Errorf("expected error 'missing root dir'; got -s0 -s0")
 	} else {
-		t.Log("--root", "--series", "--movies", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"-s", "--series", "-r", "--root", "-m", "--movies"}
+	cmd = "series -s0 yes"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'missing series dir path'")
+		t.Errorf("expected error 'missing series dir'; got -s0")
 	} else {
-		t.Log("-s", "--series", "-r", "--root", "-m", "--movies", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"-r", "-s", "-m"}
+	cmd = "movies -s0 yes"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'missing root dir path'")
+		t.Errorf("expected error 'missing movies dir'; got -s0")
 	} else {
-		t.Log("-r", "-s", "-m", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"-m", "--movies", "-r", "--root", "-s", "--series"}
+	cmd = "-s0 yes"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'missing movies dir path'")
+		t.Errorf("expected error 'missing dir'")
 	} else {
-		t.Log("-m", "--movies", "-r", "--root", "-s", "--series", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"--root", "./test_files", "./test_files"}
+	cmd = "root ./test_files series ./test_files"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'multiple values for one flag is not allowed'")
+		t.Errorf("expected error 'same dir: root test_files series test_files'")
 	} else {
-		t.Log("--root", "./test_files", "./test_files", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"-m", "./test_files", "./test_files"}
+	cmd = "root ./test_files series ./test_files/series"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'multiple values for one flag is not allowed'")
+		t.Errorf("expected error 'series is a subdir of root: root test_files series test_files/series'")
 	} else {
-		t.Log("-m", "./test_files", "./test_files", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
+	}
+	
+	cmd = "series ./test_files root ./test_files/series"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("expected error 'root is a subdir of series: series test_files root test_files/series'")
+	} else {
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"-s", "./test_files", "./test_files"}
+	cmd = "root ./test_files movies ./test_files"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'multiple values for one flag is not allowed'")
+		t.Errorf("expected error 'same dir: root test_files movies test_files'")
 	} else {
-		t.Log("-s", "./test_files", "./test_files", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"./test_files"}
+	cmd = "root ./test_files movies ./test_files/movies"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'not valid flag'")
+		t.Errorf("expected error 'movies is a subdir of root: root test_files movies test_files/movies'")
 	} else {
-		t.Log("./test_files", "\n\t", err, "\n")
+		t.Log(cmd, "\n\t", err)
+	}
+	
+	cmd = "movies ./test_files root ./test_files/movies"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("expected error 'root is a subdir of movies: movies test_files root test_files/movies'")
+	} else {
+		t.Log(cmd, "\n\t", err)
+	}
+	
+	cmd = "root ./test_files -ken ye"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("expected error 'invalid value for -ken: ye'")
+	} else {
+		t.Log(cmd, "\n\t", err)
+	}
+	
+	cmd = "root ./test_files -sen ye"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("expected error 'invalid value for -sen: ye'")
+	} else {
+		t.Log(cmd, "\n\t", err)
+	}
+		
+	cmd = "root ./test_files -s0 ye"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("expected error 'invalid value for -s0: ye'")
+	} else {
+		t.Log(cmd, "\n\t", err)
+	}
+	
+	cmd = "root ./test_files -ns ye"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("expected error 'invalid value for -ns: ye'")
+	} else {
+		t.Log(cmd, "\n\t", err)
 	}
 
-	command = []string{"-r", "./test_files", "--season-0", "all", "1"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error '1 is not a valid arg. must be yes or no'")
-	} else {
-		t.Log("-r", "./test_files", "--season-0", "all", "1", "\n\t", err, "\n")
-	}
-
-	command = []string{"-s0", "all", "yes"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root/series/movies dir path'")
-	} else {
-		t.Log("-s0", "all", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "--season-0", "yes"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'yes is not a valid arg. must be all or var'")
-	} else {
-		t.Log("-r", "./test_files", "--season-0", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-ken", "all", "yes"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root/series/movies dir path'")
-	} else {
-		t.Log("-ken", "all", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "-ken", "all", "1"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error '1 is not a valid arg. must be yes or no'")
-	} else {
-		t.Log("-r", "./test_files", "-ken", "all", "1", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "--season-0", "-s0"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'only one of --season-0 and -s0 is allowed'")
-	} else {
-		t.Log("-r", "./test_files", "--season-0", "-s0", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "-ken", "all", "yes"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'all is not a valid arg. must be yes no default or var'")
-	} else {
-		t.Log("-r", "./test_files", "-ken", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "--keep-ep-nums", "-ken"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple keep-ep-nums flags'")
-	} else {
-		t.Log("-r", "./test_files", "--keep-ep-nums", "-ken", "\n\t", err, "\n")
-	}
-
-	command = []string{"-sen", "all", "yes"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root/series/movies dir path'")
-	} else {
-		t.Log("-sen", "all", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "-sen", "all", "yes"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error '1 is not a valid arg. must be a valid positive integer'")
-	} else {
-		t.Log("-r", "./test_files", "-sen", "all", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "-sen", "all", "1"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'all is not a valid arg. must be int default or var'")
-	} else {
-		t.Log("-r", "./test_files", "-sen", "yes", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "--starting-ep-num", "-sen"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple starting-ep-num flags'")
-	} else {
-		t.Log("-r", "./test_files", "--starting-ep-num", "-sen", "\n\t", err, "\n")
-	}
-
-	command = []string{"--root", "./test_files", "-r", "./test_files"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'root directory ./test_files is a duplicate'")
-	} else {
-		t.Log("--root", "./test_files", "-r", "./test_files", "\n\t", err, "\n")
-	}
-
-	command = []string{"--root", `.\test_files`, "-s", `.\test_files\Series`, "-m", "./test_files/Movies"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'series directory ./test_files/Series is a subdirectory of root directory ./test_files'")
-	} else {
-		t.Log("--root", "./test_files", "-s", "./test_files/Series", "-m", "./test_files/Movies", "\n\t", err, "\n")
-	}
-
-	command = []string{"-r", "./test_files", "-sen", "1", "--starting-ep-num", "2"}
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'multiple starting-ep-num flags'")
-	} else {
-		t.Log("-r", "./test_files", "--naming-scheme", "S01E01", "\n\t", err, "\n")
-	}
 	t.Log("------------expects success------------")
-
-	command = []string{"--root", "./test_files", "-s0", "yes"}
+	cmd = "root ./test_files -s0 yes"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
-		t.Log("--root", "./test_files", "-s0", "yes")
+		t.Log(cmd)
 	}
-
-	command = []string{"--root", "./test_files"}
+	
+	cmd = "root ./test_files -s0 no"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
-		t.Log("--root", "./test_files")
+		t.Log(cmd)
 	}
 
-	command = []string{"--root", "./test_files", "-s0"}
+	cmd = "root ./test_files -s0 default"
+	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
-		t.Errorf("--season-0 can have no value: %s", err)
+		t.Errorf("unexpected error: %s", err)
 	} else {
-		t.Log("--root", "./test_files", "-s0")
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -s0 var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = `root ./test_files -ns "test"`
+	command = strings.Split(cmd, " ")
+	args, err := ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.namingScheme.IsNone() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			val, _ := args.options.namingScheme.Get()
+			if val != "test" {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Log(cmd)
+		}
+	}
+
+	cmd = "root ./test_files -ns default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -ns var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -ken yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "root ./test_files -ken no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -ken default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -ken var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -sen yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "root ./test_files -sen no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -sen default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "root ./test_files -sen var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = `root ./test_files -ken -sen -s0 -ns "test"`
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.namingScheme.IsNone() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			val, _ := args.options.namingScheme.Get()
+			if val != "test" {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Log(cmd)
+		}
+	}
+	
+	cmd = "root ./test_files -o"
+	command = strings.Split(cmd, " ")
+	args, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+	}
+
+	cmd = "-h"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-v"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-h -v"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-h -o"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-h -s0"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-h -ken"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-h -sen"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "-h -ns"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err == nil {
+		t.Errorf("supposed to exit safely")
+	} else {
+		t.Log(cmd, err)
+	}
+
+	cmd = "series ./test_files/series -s0 yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "series ./test_files/series -s0 no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -s0 default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -s0 var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = `series ./test_files/series -ns "test"`
+	command = strings.Split(cmd, " ")
+	args, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.namingScheme.IsNone() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			val, _ := args.options.namingScheme.Get()
+			if val != "test" {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Log(cmd)
+		}
+	}
+
+	cmd = "series ./test_files/series -ns default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -ns var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -ken yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "series ./test_files/series -ken no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -ken default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -ken var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -sen yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "series ./test_files/series -sen no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -sen default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "series ./test_files/series -sen var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = `series ./test_files/series -ken -sen -s0 -ns "test"`
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.namingScheme.IsNone() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			val, _ := args.options.namingScheme.Get()
+			if val != "test" {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Log(cmd)
+		}
+	}
+	
+	cmd = "series ./test_files/series -o"
+	command = strings.Split(cmd, " ")
+	args, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+	}
+
+	cmd = "movies ./test_files/movies -s0 yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "movies ./test_files/movies -s0 no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -s0 default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -s0 var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = `movies ./test_files/movies -ns "test"`
+	command = strings.Split(cmd, " ")
+	args, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.namingScheme.IsNone() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			val, _ := args.options.namingScheme.Get()
+			if val != "test" {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Log(cmd)
+		}
+	}
+
+	cmd = "movies ./test_files/movies -ns default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -ns var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -ken yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "movies ./test_files/movies -ken no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -ken default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -ken var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -sen yes"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+	
+	cmd = "movies ./test_files/movies -sen no"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -sen default"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = "movies ./test_files/movies -sen var"
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		t.Log(cmd)
+	}
+
+	cmd = `movies ./test_files/movies -ken -sen -s0 -ns "test"`
+	command = strings.Split(cmd, " ")
+	_, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.namingScheme.IsNone() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			val, _ := args.options.namingScheme.Get()
+			if val != "test" {
+				t.Errorf("unexpected error: %s", err)
+			}
+			t.Log(cmd)
+		}
+	}
+	
+	cmd = "movies ./test_files/movies -o"
+	command = strings.Split(cmd, " ")
+	args, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -8,7 +8,7 @@ import (
 
 func Test_ParseArgs(t *testing.T) {
 	t.Log("------------expects errors------------")
-	
+
 	cmd := "root -s0 yes"
 	command := strings.Split(cmd, " ")
 	_, err := ParseArgs(command)
@@ -62,7 +62,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
-	
+
 	cmd = "series ./test_files root ./test_files/series"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -89,7 +89,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
-	
+
 	cmd = "movies ./test_files root ./test_files/movies"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -98,7 +98,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
-	
+
 	cmd = "root ./test_files -ken ye"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -107,7 +107,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
-	
+
 	cmd = "root ./test_files -sen ye"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -116,7 +116,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
-		
+
 	cmd = "root ./test_files -s0 ye"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -125,12 +125,12 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
-	
-	cmd = "root ./test_files -ns ye"
+
+	cmd = "root ./test_files -ns yee"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	args, err := ParseArgs(command)
 	if err == nil {
-		t.Errorf("expected error 'invalid value for -ns: ye'")
+		t.Errorf("expected error 'invalid value for -ns: ye, not enclosed in double quotes'\n%s", args)
 	} else {
 		t.Log(cmd, "\n\t", err)
 	}
@@ -144,7 +144,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
+
 	cmd = "root ./test_files -s0 no"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -172,20 +172,21 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log(cmd)
 	}
 
-	cmd = `root ./test_files -ns "test"`
+	cmd = `root ./test_files -ns "test<season_num>"`
 	command = strings.Split(cmd, " ")
-	args, err := ParseArgs(command)
+	args, err = ParseArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
 		if args.options.namingScheme.IsNone() {
-			t.Errorf("unexpected error: %s", err)
+			t.Errorf("unexpected error: 'naming scheme not set'")
 		} else {
 			val, _ := args.options.namingScheme.Get()
-			if val != "test" {
-				t.Errorf("unexpected error: %s", err)
+			if val != "test<season_num>" {
+				t.Errorf("unexpected error: '%s != test<season_num>'", val)
+			} else {
+				t.Log(cmd)
 			}
-			t.Log(cmd)
 		}
 	}
 
@@ -215,7 +216,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
+
 	cmd = "root ./test_files -ken no"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -243,7 +244,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log(cmd)
 	}
 
-	cmd = "root ./test_files -sen yes"
+	cmd = "root ./test_files -sen 1"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
@@ -251,8 +252,8 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
-	cmd = "root ./test_files -sen no"
+
+	cmd = "root ./test_files -sen 2"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
@@ -281,7 +282,7 @@ func Test_ParseArgs(t *testing.T) {
 
 	cmd = `root ./test_files -ken -sen -s0 -ns "test"`
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	args, err = ParseArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
@@ -290,12 +291,12 @@ func Test_ParseArgs(t *testing.T) {
 		} else {
 			val, _ := args.options.namingScheme.Get()
 			if val != "test" {
-				t.Errorf("unexpected error: %s", err)
+				t.Errorf("unexpected error: '%s' != test", val)
 			}
 			t.Log(cmd)
 		}
 	}
-	
+
 	cmd = "root ./test_files -o"
 	command = strings.Split(cmd, " ")
 	args, err = ParseArgs(command)
@@ -389,7 +390,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
+
 	cmd = "series ./test_files/series -s0 no"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -417,7 +418,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log(cmd)
 	}
 
-	cmd = `series ./test_files/series -ns "test"`
+	cmd = `series ./test_files/series -ns "test<episode_num>"`
 	command = strings.Split(cmd, " ")
 	args, err = ParseArgs(command)
 	if err != nil {
@@ -427,10 +428,11 @@ func Test_ParseArgs(t *testing.T) {
 			t.Errorf("unexpected error: %s", err)
 		} else {
 			val, _ := args.options.namingScheme.Get()
-			if val != "test" {
-				t.Errorf("unexpected error: %s", err)
+			if val != "test<episode_num>" {
+				t.Errorf("unexpected error: '%s != test<episode_num>'", val)
+			} else {
+				t.Log(cmd)
 			}
-			t.Log(cmd)
 		}
 	}
 
@@ -460,7 +462,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
+
 	cmd = "series ./test_files/series -ken no"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -488,7 +490,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log(cmd)
 	}
 
-	cmd = "series ./test_files/series -sen yes"
+	cmd = "series ./test_files/series -sen 1"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
@@ -496,8 +498,8 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
-	cmd = "series ./test_files/series -sen no"
+
+	cmd = "series ./test_files/series -sen 2"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
@@ -526,7 +528,7 @@ func Test_ParseArgs(t *testing.T) {
 
 	cmd = `series ./test_files/series -ken -sen -s0 -ns "test"`
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	args, err = ParseArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
@@ -540,7 +542,7 @@ func Test_ParseArgs(t *testing.T) {
 			t.Log(cmd)
 		}
 	}
-	
+
 	cmd = "series ./test_files/series -o"
 	command = strings.Split(cmd, " ")
 	args, err = ParseArgs(command)
@@ -562,7 +564,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
+
 	cmd = "movies ./test_files/movies -s0 no"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -633,7 +635,7 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
+
 	cmd = "movies ./test_files/movies -ken no"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
@@ -661,7 +663,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Log(cmd)
 	}
 
-	cmd = "movies ./test_files/movies -sen yes"
+	cmd = "movies ./test_files/movies -sen 3"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
@@ -669,8 +671,8 @@ func Test_ParseArgs(t *testing.T) {
 	} else {
 		t.Log(cmd)
 	}
-	
-	cmd = "movies ./test_files/movies -sen no"
+
+	cmd = "movies ./test_files/movies -sen 4"
 	command = strings.Split(cmd, " ")
 	_, err = ParseArgs(command)
 	if err != nil {
@@ -713,7 +715,7 @@ func Test_ParseArgs(t *testing.T) {
 			t.Log(cmd)
 		}
 	}
-	
+
 	cmd = "movies ./test_files/movies -o"
 	command = strings.Split(cmd, " ")
 	args, err = ParseArgs(command)
@@ -730,105 +732,105 @@ func Test_ParseArgs(t *testing.T) {
 
 func Test_namingScheme_validation(t *testing.T) {
 	t.Log("------------expects errors------------")
-	err := ValidateNamingScheme("S<season_num:>E<episode_num:>")
+	err := ValidateNamingScheme(`"S<season_num:>E<episode_num:>"`)
 	if err == nil {
 		t.Errorf("expected error 'missing value for token: <season_num:>'")
 	} else {
 		t.Log("S<season_num:>E<episode_num:>", "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`S<season_num: 3l>`)
+	err = ValidateNamingScheme(`"S<season_num: 3l>"`)
 	if err == nil {
 		t.Errorf("expected error '3l is not a valid arg. must be a valid positive integer'")
 	} else {
 		t.Log(`S<season_num: 3l>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`S<season_num: 3`)
+	err = ValidateNamingScheme(`"S<season_num: 3"`)
 	if err == nil {
 		t.Errorf("expected error 'reached end of string but still in an unclosed api: <season_num: 3'")
 	} else {
 		t.Log(`S<season_num: 3`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<parent-parent:>`)
+	err = ValidateNamingScheme(`"<parent-parent:>"`)
 	if err == nil {
 		t.Errorf("expected error 'missing value for token: <parent-parent:>'")
 	} else {
 		t.Log(`<parent-parent:>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`E<episode_num: -2>`)
+	err = ValidateNamingScheme(`"E<episode_num: -2>"`)
 	if err == nil {
 		t.Errorf("expected error '-2 is not a valid arg. must be a valid positive integer'")
 	} else {
 		t.Log(`E<episode_num: -2>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<parent-parent:1,>`)
+	err = ValidateNamingScheme(`"<parent-parent:1,>"`)
 	if err == nil {
 		t.Errorf("expected error '1, is not a valid arg. must be two valid positive integers separated by a comma'")
 	} else {
 		t.Log(`<parent-parent:1,>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<p-3:1,2,3>`)
+	err = ValidateNamingScheme(`"<p-3:1,2,3>"`)
 	if err == nil {
 		t.Errorf("expected error '1,2,3 is not a valid arg. must be two valid positive integers separated by a comma'")
 	} else {
 		t.Log(`<p:1,2,3>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<parent: '\d+(.*)-.*>`)
+	err = ValidateNamingScheme(`"<parent: '\d+(.*)-.*>"`)
 	if err == nil {
 		t.Errorf(`expected error ' "'\d+(.*)-.*" is not a valid arg. must be a valid regex expression enclosed by two single quotes '`)
 	} else {
 		t.Log(`<parent: '\d+(.*)-.*'>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: '[]'>`)
+	err = ValidateNamingScheme(`"<self: '[]'>"`)
 	if err == nil {
 		t.Errorf(`expected error ' "[]" is not a valid regex '`)
 	} else {
 		t.Log(`<self: [>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: '>`)
+	err = ValidateNamingScheme(`"<self: '>"`)
 	if err == nil {
 		t.Errorf(`expected error ' ' is unclosed '`)
 	} else {
 		t.Log(`<self: '>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: '   '>`)
+	err = ValidateNamingScheme(`"<self: '   '>"`)
 	if err == nil {
 		t.Errorf(`expected error ' '   ' is empty '`)
 	} else {
 		t.Log(`<self: '   '>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: ' '  '>`)
+	err = ValidateNamingScheme(`"<self: ' '  '>"`)
 	if err == nil {
 		t.Errorf(`expected error ' ' '  ' is empty '`)
 	} else {
 		t.Log(`<self: ' '  '>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: 2.0,-3>`)
+	err = ValidateNamingScheme(`"<self: 2.0,-3>"`)
 	if err == nil {
 		t.Errorf(`expected error ' -2,-3 is not a valid arg. must be two valid positive integers separated by a comma'`)
 	} else {
 		t.Log(`<self: 2.0,-3>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: 'adhd' '>`)
+	err = ValidateNamingScheme(`"<self: 'adhd' '>"`)
 	if err == nil {
 		t.Errorf(`expected error ' "" is not a valid regex '`)
 	} else {
 		t.Log(`<self: 'adhd' '>`, "\n\t", err, "\n")
 	}
 
-	err = ValidateNamingScheme(`<self: 6,5>`)
+	err = ValidateNamingScheme(`"<self: 6,5>"`)
 	if err == nil {
 		t.Errorf("expected error '6,5 is not a valid range. begin (6) must be less than or equal to end (5)'")
 	} else {
@@ -837,21 +839,21 @@ func Test_namingScheme_validation(t *testing.T) {
 
 	t.Log("------------expects success------------")
 
-	err = ValidateNamingScheme("S<season_num>E<episode_num> - <parent-parent> <parent> <p-3> <self>")
+	err = ValidateNamingScheme(`"S<season_num>E<episode_num> - <parent-parent> <parent> <p-3> <self>"`)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
 		t.Log("S<season_num>E<episode_num> - <parent-parent> <parent> <p-3> <self>")
 	}
 
-	err = ValidateNamingScheme(`S<season_num: 3>E<episode_num: 2> - <parent-parent: 2,3> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self>: 5,5`)
+	err = ValidateNamingScheme(`"S<season_num: 3>E<episode_num: 2> - <parent-parent: 2,3> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self>: 5,5"`)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {
 		t.Log(`S<season_num: 3>E<episode_num: 2> - <parent-parent: 0,1> <parent: '\d+(.*)-.*'> <p-3: '(\d+)'> <self: 5,5>`)
 	}
 
-	err = ValidateNamingScheme(`<p> <p-2>`)
+	err = ValidateNamingScheme(`"<p> <p-2>"`)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err)
 	} else {

--- a/main_test.go
+++ b/main_test.go
@@ -11,741 +11,1187 @@ func Test_ParseArgs(t *testing.T) {
 
 	cmd := "root -s0 yes"
 	command := strings.Split(cmd, " ")
-	_, err := ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing root dir'; got -s0 -s0")
+	rawArgs, err := TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'missing root dir'; got -s0 -s0")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
 	}
-
 	cmd = "series -s0 yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing series dir'; got -s0")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'missing series dir'; got -s0")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "movies -s0 yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing movies dir'; got -s0")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'missing movies dir'; got -s0")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "-s0 yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'missing dir'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'missing dir'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files series ./test_files"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'same dir: root test_files series test_files'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'same dir: root test_files series test_files'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files series ./test_files/series"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'series is a subdir of root: root test_files series test_files/series'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'series is a subdir of root: root test_files series test_files/series'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "series ./test_files root ./test_files/series"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'root is a subdir of series: series test_files root test_files/series'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'root is a subdir of series: series test_files root test_files/series'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files movies ./test_files"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'same dir: root test_files movies test_files'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'same dir: root test_files movies test_files'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files movies ./test_files/movies"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'movies is a subdir of root: root test_files movies test_files/movies'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'movies is a subdir of root: root test_files movies test_files/movies'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "movies ./test_files root ./test_files/movies"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'root is a subdir of movies: movies test_files root test_files/movies'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'root is a subdir of movies: movies test_files root test_files/movies'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files -ken ye"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'invalid value for -ken: ye'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'invalid value for -ken: ye'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files -sen ye"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'invalid value for -sen: ye'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'invalid value for -sen: ye'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files -s0 ye"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'invalid value for -s0: ye'")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'invalid value for -s0: ye'")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+	}
 	cmd = "root ./test_files -ns yee"
 	command = strings.Split(cmd, " ")
-	args, err := ParseArgs(command)
-	if err == nil {
-		t.Errorf("expected error 'invalid value for -ns: ye, not enclosed in double quotes'\n%s", args)
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd, "\n\t", err)
-	}
 
-	t.Log("------------expects success------------")
+		args, err := ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'invalid value for -ns: ye, not enclosed in double quotes'\n%s", args)
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+
+		t.Log("------------expects success------------")
+	}
 	cmd = "root ./test_files -s0 yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -s0 no"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -s0 default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -s0 var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = `root ./test_files -ns "test<season_num>"`
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.namingScheme.IsNone() {
-			t.Errorf("unexpected error: 'naming scheme not set'")
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
-			val, _ := args.options.namingScheme.Get()
-			if val != "test<season_num>" {
-				t.Errorf("unexpected error: '%s != test<season_num>'", val)
+			if args.options.namingScheme.IsNone() {
+				t.Errorf("unexpected error: 'naming scheme not set'")
 			} else {
-				t.Log(cmd)
+				val, _ := args.options.namingScheme.Get()
+				if val != "test<season_num>" {
+					t.Errorf("unexpected error: '%s != test<season_num>'", val)
+				} else {
+					t.Log(cmd)
+				}
 			}
 		}
-	}
 
+	}
 	cmd = "root ./test_files -ns default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -ns var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -ken yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -ken no"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -ken default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -ken var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -sen 1"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -sen 2"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -sen default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "root ./test_files -sen var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = `root ./test_files -ken -sen -s0 -ns "test"`
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.namingScheme.IsNone() {
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			val, _ := args.options.namingScheme.Get()
-			if val != "test" {
-				t.Errorf("unexpected error: '%s' != test", val)
+			if args.options.namingScheme.IsNone() {
+				t.Errorf("unexpected error: %s", err)
+			} else {
+				val, _ := args.options.namingScheme.Get()
+				if val != "test" {
+					t.Errorf("unexpected error: '%s' != test", val)
+				}
+				t.Log(cmd)
 			}
-			t.Log(cmd)
 		}
-	}
 
+	}
 	cmd = "root ./test_files -o"
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd)
-		}
-	}
-
-	cmd = "-h"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-v"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-h -v"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-h -o"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-h -s0"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-h -ken"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-h -sen"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "-h -ns"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err == nil {
-		t.Errorf("supposed to exit safely")
-	} else {
-		t.Log(cmd, err)
-	}
-
-	cmd = "series ./test_files/series -s0 yes"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "series ./test_files/series -s0 no"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "series ./test_files/series -s0 default"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "series ./test_files/series -s0 var"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = `series ./test_files/series -ns "test<episode_num>"`
-	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		if args.options.namingScheme.IsNone() {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			val, _ := args.options.namingScheme.Get()
-			if val != "test<episode_num>" {
-				t.Errorf("unexpected error: '%s != test<episode_num>'", val)
+			if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+				t.Errorf("none of the options should have been set")
 			} else {
 				t.Log(cmd)
 			}
 		}
-	}
 
+	}
+	cmd = "-h"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-v"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-h -v"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-h -o"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-h -s0"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-h -ken"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-h -sen"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "-h -ns"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("supposed to exit safely")
+		} else {
+			t.Log(cmd, err)
+		}
+
+	}
+	cmd = "series ./test_files/series -s0 yes"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "series ./test_files/series -s0 no"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "series ./test_files/series -s0 default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "series ./test_files/series -s0 var"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = `series ./test_files/series -ns "test<episode_num>"`
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if args.options.namingScheme.IsNone() {
+				t.Errorf("unexpected error: %s", err)
+			} else {
+				val, _ := args.options.namingScheme.Get()
+				if val != "test<episode_num>" {
+					t.Errorf("unexpected error: '%s != test<episode_num>'", val)
+				} else {
+					t.Log(cmd)
+				}
+			}
+		}
+
+	}
 	cmd = "series ./test_files/series -ns default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -ns var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -ken yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -ken no"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -ken default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -ken var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -sen 1"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -sen 2"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -sen default"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = "series ./test_files/series -sen var"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
 	cmd = `series ./test_files/series -ken -sen -s0 -ns "test"`
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.namingScheme.IsNone() {
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			val, _ := args.options.namingScheme.Get()
-			if val != "test" {
+			if args.options.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
+			} else {
+				val, _ := args.options.namingScheme.Get()
+				if val != "test" {
+					t.Errorf("unexpected error: %s", err)
+				}
+				t.Log(cmd)
 			}
-			t.Log(cmd)
 		}
-	}
 
+	}
 	cmd = "series ./test_files/series -o"
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd)
+			if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+				t.Errorf("none of the options should be present")
+			} else {
+				t.Log(cmd)
+			}
 		}
-	}
 
+	}
 	cmd = "movies ./test_files/movies -s0 yes"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
 
-	cmd = "movies ./test_files/movies -s0 no"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -s0 default"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -s0 var"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = `movies ./test_files/movies -ns "test"`
-	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		if args.options.namingScheme.IsNone() {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			val, _ := args.options.namingScheme.Get()
-			if val != "test" {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "movies ./test_files/movies -s0 no"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "movies ./test_files/movies -s0 default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "movies ./test_files/movies -s0 var"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = `movies ./test_files/movies -ns "test"`
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if args.options.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
+			} else {
+				val, _ := args.options.namingScheme.Get()
+				if val != "test" {
+					t.Errorf("unexpected error: %s", err)
+				}
+				t.Log(cmd)
 			}
+		}
+
+	}
+	cmd = "movies ./test_files/movies -ns default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "movies ./test_files/movies -ns var"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "movies ./test_files/movies -ken yes"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
 			t.Log(cmd)
 		}
 	}
-
-	cmd = "movies ./test_files/movies -ns default"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -ns var"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -ken yes"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
 	cmd = "movies ./test_files/movies -ken no"
 	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -ken default"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -ken var"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -sen 3"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -sen 4"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -sen default"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = "movies ./test_files/movies -sen var"
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		t.Log(cmd)
-	}
-
-	cmd = `movies ./test_files/movies -ken -sen -s0 -ns "test"`
-	command = strings.Split(cmd, " ")
-	_, err = ParseArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: %s", err)
-	} else {
-		if args.options.namingScheme.IsNone() {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			val, _ := args.options.namingScheme.Get()
-			if val != "test" {
-				t.Errorf("unexpected error: %s", err)
-			}
 			t.Log(cmd)
+		}
+	}
+	cmd = "movies ./test_files/movies -ken default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+	}
+	cmd = "movies ./test_files/movies -ken var"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+	}
+	cmd = "movies ./test_files/movies -sen 3"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+	}
+	cmd = "movies ./test_files/movies -sen 4"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+	}
+	cmd = "movies ./test_files/movies -sen default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = "movies ./test_files/movies -sen var"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, err = ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			t.Log(cmd)
+		}
+
+	}
+	cmd = `movies ./test_files/movies -ken -sen -s0 -ns "test"`
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
+		} else {
+			if args.options.namingScheme.IsNone() {
+				t.Errorf("unexpected error: %s", err)
+			} else {
+				val, _ := args.options.namingScheme.Get()
+				if val != "test" {
+					t.Errorf("unexpected error: %s", err)
+				}
+				t.Log(cmd)
+			}
 		}
 	}
 
 	cmd = "movies ./test_files/movies -o"
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd)
+			if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+				t.Errorf(`unexpected error: keep ep nums, has season 0, starting episode num, or naming scheme should not be set when: only -o is present
+				keep ep nums: %s
+				has season 0: %s
+				starting episode num: %s
+				naming scheme: %s
+				args: %s`, args.options.keepEpNums, args.options.hasSeason0, args.options.startingEpNum, args.options.namingScheme, rawArgs)
+			} else {
+				t.Log(cmd)
+			}
 		}
 	}
 
 	cmd = "movies ./test_files/movies -ken -o"
 	command = strings.Split(cmd, " ")
-	args, err = ParseArgs(command)
+	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
-		t.Errorf("unexpected error: %s", err)
+		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		if args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
-			t.Errorf("unexpected error: has season 0, starting episode num, or naming scheme should not be set when: only -ken is set and -o is present")
+		args, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.keepEpNums.IsNone() {
-				t.Errorf("unexpected error: keep ep nums should be set to yes")
-			} else if val, _ := args.options.keepEpNums.Get(); val != true {
-				t.Errorf("unexpected error: keep ep nums should be set to yes")
+			if args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+				t.Errorf("unexpected error: has season 0, starting episode num, or naming scheme should not be set when: only -ken is set and -o is present")
 			} else {
+				if args.options.keepEpNums.IsNone() {
+					t.Errorf("unexpected error: keep ep nums should be set to yes")
+				} else if val, _ := args.options.keepEpNums.Get(); val != true {
+					t.Errorf("unexpected error: keep ep nums should be set to yes")
+				} else {
 					t.Log(cmd, "\n\t", args)
+				}
 			}
 		}
+	}
+}
+
+func Test_TokenizeArgs(t *testing.T) {
+	t.Log("------------expects errors------------")
+	t.Log("------------expects success------------")
+	strArg := "-v -h root a series e   movies i -ken m  -sen qt -s0 ux -ns yz"
+	rawArgs := strings.Split(strArg, " ")
+	args, err := TokenizeArgs(rawArgs)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else if len(args) != 9 {
+		t.Errorf("unexpected error: not enough args: %s", args)
+	} else {
+		t.Log(strArg, "\n\t", args)
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -728,6 +728,25 @@ func Test_ParseArgs(t *testing.T) {
 			t.Log(cmd)
 		}
 	}
+
+	cmd = "movies ./test_files/movies -ken -o"
+	command = strings.Split(cmd, " ")
+	args, err = ParseArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err)
+	} else {
+		if args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			t.Errorf("unexpected error: has season 0, starting episode num, or naming scheme should not be set when: only -ken is set and -o is present")
+		} else {
+			if args.options.keepEpNums.IsNone() {
+				t.Errorf("unexpected error: keep ep nums should be set to yes")
+			} else if val, _ := args.options.keepEpNums.Get(); val != true {
+				t.Errorf("unexpected error: keep ep nums should be set to yes")
+			} else {
+					t.Log(cmd, "\n\t", args)
+			}
+		}
+	}
 }
 
 func Test_namingScheme_validation(t *testing.T) {

--- a/parse_args.go
+++ b/parse_args.go
@@ -109,6 +109,7 @@ func ParseArgs(args []string) (Args, error) {
 			// use default value
 			if len(args) <= i+1 || (len(args) > i+1 && args[i+1][0] == '-') {
 				parsedArgs.options.hasSeason0 = some[bool](true)
+				isAssigned["--has-season-0"] = true
 
 			} else if args[i+1] != "yes" && args[i+1] != "var" && args[i+1] != "no" && args[i+1] != "default" {
 				return Args{}, fmt.Errorf("invalid value '%s' for flag '%s'. Must be 'yes', 'no', 'var, or 'default", args[i+1], arg)
@@ -121,8 +122,8 @@ func ParseArgs(args []string) (Args, error) {
 					parsedArgs.options.hasSeason0 = some[bool](false)
 				case "var":
 					parsedArgs.options.hasSeason0 = none[bool]()
-					isAssigned["--has-season-0"] = true
 				}
+				isAssigned["--has-season-0"] = true
 				skipValue = i + 1
 			}
 
@@ -147,8 +148,8 @@ func ParseArgs(args []string) (Args, error) {
 					parsedArgs.options.keepEpNums = some[bool](false)
 				case "var":
 					parsedArgs.options.keepEpNums = none[bool]()
-					isAssigned["--keep-ep-nums"] = true
 				}
+				isAssigned["--keep-ep-nums"] = true
 				skipValue = i + 1
 			}
 

--- a/parse_args.go
+++ b/parse_args.go
@@ -42,12 +42,9 @@ func ParseArgs(args []string) (Args, error) {
 	}
 
 	directoryArgs := map[string]bool{
-		"--root":   true,
-		"-r":       true,
-		"--series": true,
-		"-s":       true,
-		"--movies": true,
-		"-m":       true,
+		"root":   true,
+		"series": true,
+		"movies": true,
 	}
 	assignedVar := map[string]bool{
 		"--options": false,
@@ -77,7 +74,7 @@ func ParseArgs(args []string) (Args, error) {
 			return Args{}, fmt.Errorf("safe exit")
 
 		} else if arg == "--version" || arg == "-v" {
-			WelcomeMsg(version)
+			Version(version)
 			return Args{}, fmt.Errorf("safe exit")
 
 		} else if directoryArgs[arg] {

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -180,7 +180,8 @@ func PromptOptionalFlags(options AdditionalOptions, path string, level int8) Add
 				} else if strings.ToLower(input) == "exit" {
 					return options
 				} else if err := ValidateNamingScheme(input); err == nil && input != "var" {
-					options.namingScheme = some[string](input)
+					namingScheme := strings.Trim(input, `"`)
+					options.namingScheme = some[string](namingScheme)
 					break
 				} else {
 					fmt.Printf("[ERROR]\ninvalid input, please enter 'y', 'n'%s, 'default', 'exit', or a valid naming scheme\n", varOpt[1])


### PR DESCRIPTION
### changes
1. **commands are now separated into three:**
    1. commands
        - needed by **gorn** to rename stuff (`root`, `series`, and `movies`)
    2. switches
        - flags that switch the function of gorn (`-h` prints help messages instead of renaming, `-v` prints version)
    3. flags
        - modifies behavior of **gorn**
        - this is where the rest of the flags are like `--keep-ep-nums`, `--naming-scheme`, etc...
2. args are tokenized first before parsing. 
    - this is to separate flag name validation and value validation
3. `--options` now only assign `var` to flags that were not specified by the user in the initial execution of **gorn**
    - ie `gorn -r path/to/root -o` will assign `var` to every flag 
    - but `gorn -r path/to/root -ken yes -o` will assign `var` to every flag except `-ken`
    - reminder `gorn -r path/to/root -ken yes` will assign default values to every flag except `-ken`
4. stored naming scheme is now trimmed of `"`
5. help messages layout
6. updated wiki and readme to accommodate changes
