### PR TITLE
Chore/restructure codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,50 +7,51 @@ ___
     2. [Flags](#flags)
 ___ 
 # [Overview](https://github.com/saltkid/gorn/wiki)
-Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping when using jellyfin, kodi, plex, etc.
+Renames your movies and series based on directory naming and structure. Note that you still have to rename directories, just not the individual media files themselves. This is for easier metadata scraping.
 
 # [Prerequisites](https://github.com/saltkid/gorn/wiki/Directory-Structure)
 Have at least one of any of these directories:
-1. **root directory containing series roots and/or movie roots (subroots)**
+1. **root directory containing series source and/or movie source**
 ```
 <root dir>
-|__ <series root dir 1>
+|__ <series source dir 1>
 |   |__ <series entry 1>
 |   |   |__ ...
 |   |
 |   |__ <series entry 2>
 |       |__ ...
 |
-|__ <movie root dir 1>
+|__ <movie source dir 1>
     |__ <movie entry 1>
     |   |__ ...
     |
     |__ <movie entry 2>
         |__ ...
 
-where ... may mean media files or subdirectories (like extras, specials, subs, etc)
 ```
-*Note that there can be multiple series/movie subroots in the same root directory.*
+*where ... may mean media files or subdirectories (like extras, specials, subs, etc)*
 
-2. **series subroot directory containing series entries**
+*Note that there can be multiple series/movie sources in the same root directory.*
+
+2. **series source directory containing series entries**
 ```
-<series root dir 1>
+<series source dir 1>
 |__ <series entry 1>
 |   |__ ...
 |
 |__ <series entry 2>
     |__ ...
 ```
-3. **movie subroot directory containing movie entries**
+3. **movie source directory containing movie entries**
 ```
-<movie root dir 1>
+<movie source dir 1>
     |__ <movie entry 1>
     |   |__ ...
     |
     |__ <movie entry 2>
         |__ ...
 ```
-For a more detailed explanation of recommended directory structures, different series/movie types depending on structure, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)
+For a more detailed explanation of recommended directory structures, different series/movie types, default naming schemes, and more, see [this wiki page](https://github.com/saltkid/gorn/wiki/Directory-Structure)
 ___
 # [Usage](https://github.com/saltkid/gorn/wiki/Usage)
 To rename all series and movies in the root directory based on directory naming and structure:
@@ -58,20 +59,20 @@ To rename all series and movies in the root directory based on directory naming 
 gorn root path/to/root/dir
 ```
 
-User can specify multiple root/subroot directories to rename:
+User can specify multiple root/source directories to rename:
 ```
 gorn root path/to/root/dir root path/to/another/root/dir
 ```
 
-User can specify series and movie subroot dirs separately. User can also specify multiple subroot dirs. Other than that, it shares the same default renaming behavior as specifying a root dir
+User can specify series and movie source dirs separately. User can also specify multiple source dirs. Other than that, it shares the same default renaming behavior as specifying a root dir
 ```
-gorn series path/to/series/subroot/dir
-```
-```
-gorn movies path/to/movies/subroot/dir
+gorn series path/to/series/source/dir
 ```
 ```
-gorn root path/to/root/dir series path/to/series/subroot/dir movies path/to/movies/subroot/dir
+gorn movies path/to/movies/source/dir
+```
+```
+gorn root path/to/root/dir series path/to/series/source/dir movies path/to/movies/source/dir
 ```
 ## [Switches](https://github.com/saltkid/gorn/wiki/Usage#switches)
 Switches are flags that switch the behavior of **gorn** from its default behavior of renaming media files. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#switches)

--- a/help.go
+++ b/help.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"fmt"
+	"log"
+)
 
 func WelcomeMsg(version string) {
 	Version(version)
@@ -14,8 +17,8 @@ func Version(version string) {
 	fmt.Println("version:", version)
 }
 
-func Help(flag string) {
-	switch flag {
+func Help(val string) {
+	switch val {
 	case "":
 		fmt.Println("Usage")
 		fmt.Println("\n  gorn root <path/to/root>")
@@ -56,7 +59,7 @@ func Help(flag string) {
 	case "-ns", "--naming-scheme":
 		HelpNS(true)
 	default:
-		fmt.Printf("invalid flag: %s\n\n", flag)
+		log.Println(WARN, "invalid value for 'help':", val) 
 		Help("")
 	}
 }

--- a/main.go
+++ b/main.go
@@ -61,6 +61,8 @@ func ProcessMedia(mediaFiles MediaFiles, entries []string, flags Flags, wg *sync
 }
 
 func LogRawEntries(seriesEntries []string, movieEntries []string) {
+	defer timer("LogRawEntries")()
+	
 	log.Println(INFO, "series dirs (", len(seriesEntries), "): ")
 	for _, series := range seriesEntries {
 		log.Println(INFO, "\t", series)
@@ -80,6 +82,8 @@ func LogRawEntries(seriesEntries []string, movieEntries []string) {
 //
 // Returns the series entries and movie entries as string slices.
 func FetchEntries(rootDirs []string, seriesDirs []string, movieDirs []string) ([]string, []string) {
+	defer timer("FetchEntries")()
+
 	entries := map[string][]string{
 		"movies": make([]string, 0),
 		"series": make([]string, 0),

--- a/main.go
+++ b/main.go
@@ -147,7 +147,7 @@ func SeparateRoots(root string) (map[string][]string) {
 	})
 
 	if err != nil {
-		log.Println(WARN, "there was an error reading root directory", err)
+		log.Println(WARN, "reading root directory error:", err)
 	}
 
 	if len(rootDirs["movies"]) == 0 && len(rootDirs["series"]) == 0 {

--- a/main.go
+++ b/main.go
@@ -20,7 +20,7 @@ func main() {
 	args, err := ParseArgs(rawArgs)
 	if err != nil {
 		// scuffed safe exit for --help and --version
-		if err.Error() == "safe exit" { return }
+		if _, ok := err.(SafeError); ok { return }
 		panic(err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"log"
 )
 
 var version string
@@ -17,26 +18,18 @@ func main() {
 		return
 	}
 	rawArgs, err := TokenizeArgs(os.Args[1:])
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
-	}
+	if err != nil { log.Fatalln(FATAL, err) }
 
 	args, err := ParseArgs(rawArgs)
 	if err != nil {
 		// scuffed safe exit for --help and --version
-		if _, ok := err.(SafeError); !ok {
-			fmt.Println("Error:", err)
-		}
+		if _, ok := err.(SafeError); !ok { log.Fatalln(FATAL, err) }
 		return
 	}
 	go LogArgs(args)
 
 	err = start(args)
-	if err != nil {
-		fmt.Println("Error:", err)
-		return
-	}
+	if err != nil { log.Fatalln(FATAL, err) }
 }
 
 func start(args Args) error {
@@ -50,64 +43,64 @@ func start(args Args) error {
 	err = series.SplitByType(seriesEntries)
 	if err != nil { return err }
 	go series.LogEntries()
-	err = series.RenameEntries(args.options)
-	if err != nil { return err }
+	// err = series.RenameEntries(args.options)
+	// if err != nil { return err }
 
 	movies := &Movies{}
 	err = movies.SplitByType(movieEntries)
 	if err != nil { return err }
 	go movies.LogEntries()
-	err = movies.RenameEntries(args.options)
-	if err != nil { return err }
+	// err = movies.RenameEntries(args.options)
+	// if err != nil { return err }
 
 	return nil
 }
 
 func LogArgs(args Args) {
 	if len(args.root) > 0 {
-		fmt.Println("roots:")
+		log.Println(INFO, "root directories: ")
 		for _, root := range args.root {
-			fmt.Println("\t", root)
+			log.Println(INFO, "\t", root)
 		}
 	}
 	if len(args.series) > 0 {
-		fmt.Println("series:")
+		log.Println(INFO, "series sources:")
 		for _, series := range args.series {
-			fmt.Println("\t", series)
+			log.Println(INFO, "\t", series)
 		}
 	}
 	if len(args.movies) > 0 {
-		fmt.Println("movies:")
+		log.Println(INFO, "movies sources:")
 		for _, movie := range args.movies {
-			fmt.Println("\t", movie)
+			log.Println(INFO, "\t", movie)
 		}
 	}
 	ken, err := args.options.keepEpNums.Get()
 	if err == nil {
-		fmt.Println("keep episode numbers: ", ken)
+		log.Println(INFO, "keep episode numbers: ", ken)
 	}
 	sen, err := args.options.startingEpNum.Get()
 	if err == nil {
-		fmt.Println("starting episode number: ", sen)
+		log.Println(INFO, "starting episode number: ", sen)
 	}
 	s0, err := args.options.hasSeason0.Get()
 	if err == nil {
-		fmt.Println("has season 0: ", s0)
+		log.Println(INFO, "has season 0: ", s0)
 	}
 	ns, err := args.options.namingScheme.Get()
 	if err == nil {
-		fmt.Println("naming scheme: ", ns)
+		log.Println(INFO, "naming scheme: ", ns)
 	}
 }
 
 func LogRawEntries(seriesEntries []string, movieEntries []string) {
-	fmt.Println("series dirs (", len(seriesEntries), "): ")
+	log.Println(INFO, "series dirs (", len(seriesEntries), "): ")
 	for _, series := range seriesEntries {
-		fmt.Println("\t", series)
+		log.Println(INFO, "\t", series)
 	}
-	fmt.Println("movie dirs (", len(movieEntries), "): ")
+	log.Println(INFO, "movie dirs (", len(movieEntries), "): ")
 	for _, movie := range movieEntries {
-		fmt.Println("\t", movie)
+		log.Println(INFO, "\t", movie)
 	}
 	fmt.Println()
 }

--- a/main.go
+++ b/main.go
@@ -147,11 +147,7 @@ func SeparateRoots(root string) (map[string][]string) {
 	})
 
 	if err != nil {
-		log.Println(ERROR, err)
-		return map[string][]string{
-			"movies": {},
-			"series": {},
-		}
+		log.Println(WARN, "there was an error reading root directory", err)
 	}
 
 	if len(rootDirs["movies"]) == 0 && len(rootDirs["series"]) == 0 {
@@ -178,8 +174,7 @@ func FetchSubdirs(dir string) []string {
 	})
 
 	if err != nil {
-		log.Println(ERROR, err)
-		return []string{}
+		log.Println(WARN, "there was an error reading directory:", err)
 	}
 
 	if len(entries) == 0 {

--- a/main.go
+++ b/main.go
@@ -14,6 +14,8 @@ var version string
 func main() {
 	defer timer("main")()
 
+	// handling input of user
+	// errors can happen here and interrupt the process
 	if len(os.Args) < 2 {
 		WelcomeMsg(version)
 		return
@@ -29,26 +31,30 @@ func main() {
 	}
 	args.Log()
 
+	// renaming process
+	// there should be no errors in renaming process since:
+	//   - we already checked for errors in ParseArgs and TokenizeArgs
+	//   - we can safely skip renaming a file if an error does occur
 	seriesEntries, movieEntries := FetchEntries(args.root, args.series, args.movies)
 	LogRawEntries(seriesEntries, movieEntries)
-	
+
 	wg := new(sync.WaitGroup)
 
 	series := &Series{}
 	wg.Add(1)
-	go processMedia(series, seriesEntries, args.options, wg)
+	go ProcessMedia(series, seriesEntries, args.options, wg)
 
 	movies := &Movies{}
 	wg.Add(1)
-	go processMedia(movies, movieEntries, args.options, wg)
-	
+	go ProcessMedia(movies, movieEntries, args.options, wg)
+
 	wg.Wait()
 	movies.LogEntries()
 	series.LogEntries()
 }
 
-func processMedia(mediaFiles MediaFiles, entries []string, flags Flags, wg *sync.WaitGroup) {
-	defer timer("processMedia")()
+func ProcessMedia(mediaFiles MediaFiles, entries []string, flags Flags, wg *sync.WaitGroup) {
+	defer timer("ProcessMedia")()
 	mediaFiles.SplitByType(entries)
 	mediaFiles.RenameEntries(flags)
 	wg.Done()

--- a/main.go
+++ b/main.go
@@ -15,17 +15,25 @@ func main() {
 		return
 	}
 	rawArgs, err := TokenizeArgs(os.Args[1:])
-	if err != nil { panic(err) }
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
 
 	args, err := ParseArgs(rawArgs)
 	if err != nil {
 		// scuffed safe exit for --help and --version
-		if _, ok := err.(SafeError); ok { return }
-		panic(err)
+		if _, ok := err.(SafeError); !ok {
+			fmt.Println("Error:", err)
+		}
+		return
 	}
 
 	err = start(args)
-	if err != nil { panic(err) }
+	if err != nil {
+		fmt.Println("Error:", err)
+		return
+	}
 }
 
 func start(args Args) error {

--- a/main.go
+++ b/main.go
@@ -32,35 +32,25 @@ func main() {
 	seriesEntries, movieEntries := FetchEntries(args.root, args.series, args.movies)
 	LogRawEntries(seriesEntries, movieEntries)
 	
-	var errChan = make(chan error, 2)
 	wg := new(sync.WaitGroup)
 
 	series := &Series{}
 	wg.Add(1)
-	go processMedia(series, seriesEntries, args.options, wg, errChan)
+	go processMedia(series, seriesEntries, args.options, wg)
 
 	movies := &Movies{}
 	wg.Add(1)
-	go processMedia(movies, movieEntries, args.options, wg, errChan)
+	go processMedia(movies, movieEntries, args.options, wg)
 	
 	wg.Wait()
-	close(errChan)
-	for err := range errChan {
-		log.Println(ERROR, err)
-	}
-
 	movies.LogEntries()
 	series.LogEntries()
 }
 
-func processMedia(mediaFiles MediaFiles, entries []string, flags Flags, wg *sync.WaitGroup, errChan chan error) {
+func processMedia(mediaFiles MediaFiles, entries []string, flags Flags, wg *sync.WaitGroup) {
 	defer timer("processMedia")()
-
 	mediaFiles.SplitByType(entries)
-	err := mediaFiles.RenameEntries(flags)
-	if err != nil {
-		errChan <- err
-	}
+	mediaFiles.RenameEntries(flags)
 	wg.Done()
 }
 

--- a/main.go
+++ b/main.go
@@ -10,6 +10,8 @@ import (
 var version string
 
 func main() {
+	defer timer("main")()
+
 	if len(os.Args) < 2 {
 		WelcomeMsg(version)
 		return
@@ -28,6 +30,7 @@ func main() {
 		}
 		return
 	}
+	go LogArgs(args)
 
 	err = start(args)
 	if err != nil {
@@ -37,23 +40,23 @@ func main() {
 }
 
 func start(args Args) error {
-	LogArgs(args)
+	defer timer("start")()
 
 	seriesEntries, movieEntries, err := FetchEntries(args.root, args.series, args.movies)
 	if err != nil { return err }
-	LogRawEntries(seriesEntries, movieEntries)
+	go LogRawEntries(seriesEntries, movieEntries)
 
 	series := &Series{}
 	err = series.SplitByType(seriesEntries)
 	if err != nil { return err }
-	series.LogEntries()
+	go series.LogEntries()
 	err = series.RenameEntries(args.options)
 	if err != nil { return err }
 
 	movies := &Movies{}
 	err = movies.SplitByType(movieEntries)
 	if err != nil { return err }
-	movies.LogEntries()
+	go movies.LogEntries()
 	err = movies.RenameEntries(args.options)
 	if err != nil { return err }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1408,6 +1408,21 @@ func Test_SplitRegexByPipe(t *testing.T) {
 			t.Log("\t", part, "has only one match group?", HasOnlyOneMatchGroup(part))
 		}
 	}
+
+	parts = SplitRegexByPipe(`(a(b)c)|d`)
+	if len(parts) != 2 {
+		if parts[0] != "(a(b)c)" {
+			t.Errorf("expected '(a(b)c)'; got '%s'", parts[0])
+		}
+		if parts[1] != "d" {
+			t.Errorf("expected 'd'; got '%s'", parts[1])
+		}
+	} else {
+		t.Log(`'(a(b)c)|d'`, "\n\t", parts)
+		for _, part := range parts {
+			t.Log("\t", part, "has only one match group?", HasOnlyOneMatchGroup(part))
+		}
+	}
 }
 
 func Test_GenerateNewName(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1409,16 +1409,46 @@ func Test_SplitRegexByPipe(t *testing.T) {
 		}
 	}
 
-	parts = SplitRegexByPipe(`(a(b)c)|d`)
+	parts = SplitRegexByPipe(`(a\(b\)c)|d`)
 	if len(parts) != 2 {
-		if parts[0] != "(a(b)c)" {
-			t.Errorf("expected '(a(b)c)'; got '%s'", parts[0])
+		if parts[0] != `(a\(b\)c)` {
+			t.Errorf(`expected '(a\(b\)c)'; got '%s'`, parts[0])
 		}
-		if parts[1] != "d" {
+		if len(parts) > 1 && parts[1] != "d" {
 			t.Errorf("expected 'd'; got '%s'", parts[1])
 		}
 	} else {
-		t.Log(`'(a(b)c)|d'`, "\n\t", parts)
+		t.Log(`'(a\(b\)c)|d'`, "\n\t", parts)
+		for _, part := range parts {
+			t.Log("\t", part, "has only one match group?", HasOnlyOneMatchGroup(part))
+		}
+	}
+
+	parts = SplitRegexByPipe(`(a[(b)]c)|d`)
+	if len(parts) != 2 {
+		if parts[0] != `(a[(b)]c)` {
+			t.Errorf(`expected '(a[(b)]c)'; got '%s'`, parts[0])
+		}
+		if len(parts) > 1 && parts[1] != "d" {
+			t.Errorf("expected 'd'; got '%s'", parts[1])
+		}
+	} else {
+		t.Log(`'(a[(b)]c)|d'`, "\n\t", parts)
+		for _, part := range parts {
+			t.Log("\t", part, "has only one match group?", HasOnlyOneMatchGroup(part))
+		}
+	}
+
+	parts = SplitRegexByPipe(`(a\[\(b\)\]c)|d`)
+	if len(parts) != 2 {
+		if parts[0] != `(a\[\(b\)\]c)` {
+			t.Errorf(`expected '(a\[\(b\)\]c)'; got '%s'`, parts[0])
+		}
+		if len(parts) > 1 && parts[1] != "d" {
+			t.Errorf("expected 'd'; got '%s'", parts[1])
+		}
+	} else {
+		t.Log(`'(a\[\(b\)\]c)|d'`, "\n\t", parts)
 		for _, part := range parts {
 			t.Log("\t", part, "has only one match group?", HasOnlyOneMatchGroup(part))
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1413,30 +1413,13 @@ func Test_SplitRegexByPipe(t *testing.T) {
 func Test_GenerateNewName(t *testing.T) {
 	path := filepath.Clean(`.test_files\Series\Series_seasonal\Season 1\1234567890.mp4`)
 	t.Log("------------expects success------------")
-	name, err := GenerateNewName(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`),
+	name := GenerateNewName(some[string](`S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`),
 		2, 1, 3, 2,
 		"title", path)
-	if err != nil {
-		t.Error("expected no error; got", err)
+	if !strings.EqualFold(name, `.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4`) {
+		t.Error(`expected '.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4' got`, name)
 	} else {
-		if strings.ReplaceAll(name, `.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4`, "") != "" {
-			t.Errorf(`expected '.test_files\Series\Series_seasonal\Season 1\S001E02 - Series Season ies 67.mp4' got '%s'`, name)
-		} else {
-			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
-		}
-	}
-
-	name, err = GenerateNewName(some[string](`<p>`),
-		2, 1, 3, 2,
-		"title", path)
-	if err != nil {
-		t.Error("expected no error; got", err)
-	} else {
-		if strings.ReplaceAll(name, `.test_files\Series\Series_seasonal\Season 1\Season 1.mp4`, "") != "" {
-			t.Errorf(`expected '.test_files\Series\Series_seasonal\Season 1\Season 1.mp4' got '%s'`, name)
-		} else {
-			t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `<p> <p-2>`, "\n\tnew:\t\t", name)
-		}
+		t.Log("\n\told:\t\t", filepath.Base(path), "\n\tnaming scheme:\t", `S<season_num: 3>E<episode_num: 2> - <parent-parent: '([^_]+)_.*$'> <parent: '([^ ]+) \d+'> <p-3: 'r(.*)$'> <self: 5,6>`, "\n\tnew:\t\t", name)
 	}
 
 }

--- a/media_files.go
+++ b/media_files.go
@@ -10,8 +10,8 @@ import (
 
 type MediaFiles interface {
 	SplitByType(entries []string)
+	RenameEntries(Flags)
 	LogEntries()
-	RenameEntries(Flags) error
 }
 
 type Movies struct {
@@ -112,6 +112,55 @@ func (series *Series) SplitByType(entries []string) {
 	}
 }
 
+func (movies *Movies) RenameEntries(options Flags) {
+	log.Println(INFO, "Renaming standalone movies")
+	for _, v := range movies.standalone {
+		info := MovieRenamePrereqs(v, STANDALONE)
+		info.Rename()
+	}
+	fmt.Println()
+
+	log.Println(INFO, "Renaming movie set")
+	for _, v := range movies.movieSet {
+		info := MovieRenamePrereqs(v, MOVIE_SET)
+		info.Rename()
+	}
+	fmt.Println()
+}
+
+func (series *Series) RenameEntries(options Flags) {
+	log.Println(INFO, "Renaming named seasons")
+	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
+	for _, v := range series.namedSeasons {
+		info := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
+		info.Rename()
+	}
+	log.Println(INFO, "Renaming single season no movies")
+	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
+	for _, v := range series.singleSeasonNoMovies {
+		info := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
+		info.Rename()
+	}
+	log.Println(INFO, "Renaming single season with movies")
+	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
+	for _, v := range series.singleSeasonWithMovies {
+		info := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
+		info.Rename()
+	}
+	log.Println(INFO, "Renaming multiple season no movies")
+	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
+	for _, v := range series.multipleSeasonNoMovies {
+		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
+		info.Rename()
+	}
+	log.Println(INFO, "Renaming multiple season with movies")
+	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
+	for _, v := range series.multipleSeasonWithMovies {
+		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
+		info.Rename()
+	}
+}
+
 func (movie *Movies) LogEntries() {
 	log.Println(INFO, "categorized movies: ")
 	log.Println(INFO, "standalone: ")
@@ -146,66 +195,4 @@ func (series *Series) LogEntries() {
 	for _, v := range series.multipleSeasonWithMovies {
 		log.Println(INFO, "\t", v)
 	}
-}
-
-func (movies *Movies) RenameEntries(options Flags) error {
-	log.Println(INFO, "Renaming standalone movies")
-	for _, v := range movies.standalone {
-		info := MovieRenamePrereqs(v, STANDALONE)
-		info.Rename()
-	}
-	fmt.Println()
-
-	log.Println(INFO, "Renaming movie set")
-	for _, v := range movies.movieSet {
-		info := MovieRenamePrereqs(v, MOVIE_SET)
-		info.Rename()
-	}
-	fmt.Println()
-
-	return nil
-}
-
-func (series *Series) RenameEntries(options Flags) error {
-	log.Println(INFO, "Renaming named seasons")
-	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
-	for _, v := range series.namedSeasons {
-		info := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
-		info.Rename()
-	}
-	fmt.Println()
-
-	log.Println(INFO, "Renaming single season no movies")
-	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
-	for _, v := range series.singleSeasonNoMovies {
-		info := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
-		info.Rename()
-	}
-	fmt.Println()
-
-	log.Println(INFO, "Renaming single season with movies")
-	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
-	for _, v := range series.singleSeasonWithMovies {
-		info := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
-		info.Rename()
-	}
-	fmt.Println()
-
-	log.Println(INFO, "Renaming multiple season no movies")
-	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
-	for _, v := range series.multipleSeasonNoMovies {
-		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
-		info.Rename()
-	}
-	fmt.Println()
-
-	log.Println(INFO, "Renaming multiple season with movies")
-	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
-	for _, v := range series.multipleSeasonWithMovies {
-		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
-		info.Rename()
-	}
-	fmt.Println()
-
-	return nil
 }

--- a/media_files.go
+++ b/media_files.go
@@ -154,28 +154,20 @@ func (movies *Movies) RenameEntries(options Flags) error {
 	fmt.Println("Renaming standalone movies")
 	for _, v := range movies.standalone {
 		info, err := MovieRenamePrereqs(v, STANDALONE)
-		if err != nil {
-			panic(err)
-		}
+		if err != nil { return err }
 
 		err = info.Rename()
-		if err != nil {
-			panic(err)
-		}
+		if err != nil { return err }
 	}
 	fmt.Println()
 
 	fmt.Println("Renaming movie set")
 	for _, v := range movies.movieSet {
 		info, err := MovieRenamePrereqs(v, MOVIE_SET)
-		if err != nil {
-			panic(err)
-		}
+		if err != nil { return err }
 
 		err = info.Rename()
-		if err != nil {
-			panic(err)
-		}
+		if err != nil { return err }
 	}
 	fmt.Println()
 

--- a/media_files.go
+++ b/media_files.go
@@ -11,7 +11,7 @@ import (
 type MediaFiles interface {
 	SplitByType(entries []string) error
 	LogEntries()
-	RenameEntries(Flags) error
+	RenameEntries(Flags)
 }
 
 type Movies struct {
@@ -38,12 +38,9 @@ const (
 	MULTIPLE_SEASON_WITH_MOVIES = "multipleSeasonWithMovies"
 )
 
-func (movie *Movies) SplitByType(entries []string) error {
+func (movie *Movies) SplitByType(entries []string) {
 	for _, movieEntry := range entries {
-		files, err := os.ReadDir(movieEntry)
-		if err != nil {
-			return err
-		}
+		files, _ := os.ReadDir(movieEntry)
 
 		extrasPattern := regexp.MustCompile(`^(?i)specials?|extras?|trailers?`)
 
@@ -58,16 +55,12 @@ func (movie *Movies) SplitByType(entries []string) error {
 			}
 		}
 	}
-	return nil
 }
 
-func (series *Series) SplitByType(entries []string) error {
+func (series *Series) SplitByType(entries []string) {
 	for _, seriesEntry := range entries {
-		files, err := os.ReadDir(seriesEntry)
-		if err != nil {
-			return err
-		}
-
+		files, _ := os.ReadDir(seriesEntry)
+		
 		namedSeasonsPattern := regexp.MustCompile(`^\d+\.\s+(.*)$`)
 		seasonalPattern := regexp.MustCompile(`^(?i)season\s+(\d+)`)
 		possiblySingleSeason := false
@@ -84,10 +77,7 @@ func (series *Series) SplitByType(entries []string) error {
 					break
 
 				} else if seasonalPattern.MatchString(file.Name()) {
-					HasMovie, err := HasMovie(seriesEntry)
-					if err != nil {
-						return err
-					}
+					HasMovie, _ := HasMovie(seriesEntry)
 
 					if HasMovie {
 						series.multipleSeasonWithMovies = append(series.multipleSeasonWithMovies, seriesEntry)
@@ -110,7 +100,6 @@ func (series *Series) SplitByType(entries []string) error {
 			series.singleSeasonNoMovies = append(series.singleSeasonNoMovies, seriesEntry)
 		}
 	}
-	return nil
 }
 
 func (movie *Movies) LogEntries() {

--- a/media_files.go
+++ b/media_files.go
@@ -164,6 +164,8 @@ func (series *Series) RenameEntries(options Flags) {
 }
 
 func (movie *Movies) LogEntries() {
+	defer timer("movies LogEntries")()
+
 	log.Println(INFO, "categorized movies: ")
 	log.Println(INFO, "standalone: ")
 	for _, v := range movie.standalone {
@@ -176,6 +178,7 @@ func (movie *Movies) LogEntries() {
 }
 
 func (series *Series) LogEntries() {
+	defer timer("series LogEntries")()
 	log.Println(INFO, "categorized series: ")
 	log.Println(INFO, "named seasons: ")
 	for _, v := range series.namedSeasons {

--- a/media_files.go
+++ b/media_files.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"sync"
 )
 
 type MediaFiles interface {
@@ -103,10 +102,7 @@ func (series *Series) SplitByType(entries []string) {
 	}
 }
 
-func (movie *Movies) LogEntries(wg *sync.WaitGroup) {
-	wg.Add(1)
-	defer wg.Done()
-
+func (movie *Movies) LogEntries() {
 	log.Println(INFO, "categorized movies: ")
 	log.Println(INFO, "standalone: ")
 	for _, v := range movie.standalone {
@@ -118,10 +114,7 @@ func (movie *Movies) LogEntries(wg *sync.WaitGroup) {
 	}
 }
 
-func (series *Series) LogEntries(wg *sync.WaitGroup) {
-	wg.Add(1)
-	defer wg.Done()
-
+func (series *Series) LogEntries() {
 	log.Println(INFO, "categorized series: ")
 	log.Println(INFO, "named seasons: ")
 	for _, v := range series.namedSeasons {
@@ -146,17 +139,17 @@ func (series *Series) LogEntries(wg *sync.WaitGroup) {
 }
 
 func (movies *Movies) RenameEntries(options Flags) error {
-	fmt.Println("Renaming standalone movies")
+	log.Println(INFO, "Renaming standalone movies")
 	for _, v := range movies.standalone {
 		info, err := MovieRenamePrereqs(v, STANDALONE)
 		if err != nil { return err }
-
+	
 		err = info.Rename()
 		if err != nil { return err }
 	}
 	fmt.Println()
 
-	fmt.Println("Renaming movie set")
+	log.Println(INFO, "Renaming movie set")
 	for _, v := range movies.movieSet {
 		info, err := MovieRenamePrereqs(v, MOVIE_SET)
 		if err != nil { return err }
@@ -170,7 +163,7 @@ func (movies *Movies) RenameEntries(options Flags) error {
 }
 
 func (series *Series) RenameEntries(options Flags) error {
-	fmt.Println("Renaming named seasons")
+	log.Println(INFO, "Renaming named seasons")
 	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
 	for _, v := range series.namedSeasons {
 		info, err := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
@@ -185,7 +178,7 @@ func (series *Series) RenameEntries(options Flags) error {
 	}
 	fmt.Println()
 
-	fmt.Println("Renaming single season no movies")
+	log.Println(INFO, "Renaming single season no movies")
 	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
 	for _, v := range series.singleSeasonNoMovies {
 		info, err := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
@@ -200,7 +193,7 @@ func (series *Series) RenameEntries(options Flags) error {
 	}
 	fmt.Println()
 
-	fmt.Println("Renaming single season with movies")
+	log.Println(INFO, "Renaming single season with movies")
 	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
 	for _, v := range series.singleSeasonWithMovies {
 		info, err := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
@@ -215,7 +208,7 @@ func (series *Series) RenameEntries(options Flags) error {
 	}
 	fmt.Println()
 
-	fmt.Println("Renaming multiple season no movies")
+	log.Println(INFO, "Renaming multiple season no movies")
 	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
 	for _, v := range series.multipleSeasonNoMovies {
 		info, err := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
@@ -230,7 +223,7 @@ func (series *Series) RenameEntries(options Flags) error {
 	}
 	fmt.Println()
 
-	fmt.Println("Renaming multiple season with movies")
+	log.Println(INFO, "Renaming multiple season with movies")
 	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
 	for _, v := range series.multipleSeasonWithMovies {
 		info, err := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)

--- a/media_files.go
+++ b/media_files.go
@@ -9,9 +9,9 @@ import (
 )
 
 type MediaFiles interface {
-	SplitByType(entries []string) error
+	SplitByType(entries []string)
 	LogEntries()
-	RenameEntries(Flags)
+	RenameEntries(Flags) error
 }
 
 type Movies struct {

--- a/media_files.go
+++ b/media_files.go
@@ -11,7 +11,7 @@ import (
 type MediaFiles interface {
 	SplitByType(entries []string) error
 	LogEntries()
-	RenameEntries()
+	RenameEntries(Flags) error
 }
 
 type Movies struct {

--- a/media_files.go
+++ b/media_files.go
@@ -137,41 +137,65 @@ func (movies *Movies) RenameEntries(options Flags) {
 }
 
 func (series *Series) RenameEntries(options Flags) {
+	wg := new(sync.WaitGroup)
+
 	log.Println(INFO, "Renaming named seasons...")
 	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
 	for _, v := range series.namedSeasons {
-		info := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
-		info.Rename()
+		wg.Add(1)
+		go func(v string){
+			info := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
+			info.Rename()
+			wg.Done()
+		}(v)
 	}
-	log.Println(INFO, "Done renaming named seasons.")
+	
 	log.Println(INFO, "Renaming single season no movies...")
 	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
 	for _, v := range series.singleSeasonNoMovies {
-		info := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
-		info.Rename()
+		wg.Add(1)
+		go func(v string){
+			info := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
+			info.Rename()
+			wg.Done()
+		}(v)
 	}
-	log.Println(INFO, "Done renaming single season no movies.")
+	
 	log.Println(INFO, "Renaming single season with movies...")
 	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
 	for _, v := range series.singleSeasonWithMovies {
-		info := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
-		info.Rename()
+		wg.Add(1)
+		go func(v string) {
+			info := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
+			info.Rename()
+			wg.Done()
+		}(v)
 	}
-	log.Println(INFO, "Done renaming single season with movies.")
+	
 	log.Println(INFO, "Renaming multiple season no movies...")
 	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
 	for _, v := range series.multipleSeasonNoMovies {
-		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
-		info.Rename()
+		wg.Add(1)
+		go func(v string){
+			info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
+			info.Rename()
+			wg.Done()
+		}(v)
 	}
-	log.Println(INFO, "Done renaming multiple season no movies.")
+	
 	log.Println(INFO, "Renaming multiple season with movies...")
 	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
 	for _, v := range series.multipleSeasonWithMovies {
-		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
-		info.Rename()
+		wg.Add(1)
+		go func(v string){
+			info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
+			info.Rename()
+			wg.Done()
+		}(v)
 	}
-	log.Println(INFO, "Done renaming multiple season with movies.")
+	
+	wg.Wait()
+	log.Println(INFO, "Done renaming series entries.")
 }
 
 func (movie *Movies) LogEntries() {

--- a/media_files.go
+++ b/media_files.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"log"
 	"os"
 	"path/filepath"
@@ -42,8 +41,7 @@ func (movie *Movies) SplitByType(entries []string) {
 	for _, movieEntry := range entries {
 		files, err := os.ReadDir(movieEntry)
 		if err != nil {
-			log.Println(ERROR, "error reading movie entry:", movieEntry)
-			log.Println(ERROR, "skipping categorizing entry:", movieEntry)
+			log.Println(WARN, "there was anerror reading movie entry:", err, "; skipping categorizing entry:", movieEntry)
 			continue
 		}
 
@@ -66,8 +64,7 @@ func (series *Series) SplitByType(entries []string) {
 	for _, seriesEntry := range entries {
 		files, err := os.ReadDir(seriesEntry)
 		if err != nil {
-			log.Println(ERROR, "error reading series entry:", seriesEntry)
-			log.Println(ERROR, "skipping categorizing entry:", seriesEntry)
+			log.Println(WARN, "there was an error reading series entry:", err, "; skipping categorizing entry:", seriesEntry)
 			continue
 		}
 		
@@ -113,52 +110,57 @@ func (series *Series) SplitByType(entries []string) {
 }
 
 func (movies *Movies) RenameEntries(options Flags) {
-	log.Println(INFO, "Renaming standalone movies")
+	log.Println(INFO, "Renaming standalone movies..")
 	for _, v := range movies.standalone {
 		info := MovieRenamePrereqs(v, STANDALONE)
 		info.Rename()
 	}
-	fmt.Println()
+	log.Println(INFO, "Done renaming standalone movies.")
 
-	log.Println(INFO, "Renaming movie set")
+	log.Println(INFO, "Renaming movie sets...")
 	for _, v := range movies.movieSet {
 		info := MovieRenamePrereqs(v, MOVIE_SET)
 		info.Rename()
 	}
-	fmt.Println()
+	log.Println(INFO, "Done renaming movie sets.")
 }
 
 func (series *Series) RenameEntries(options Flags) {
-	log.Println(INFO, "Renaming named seasons")
+	log.Println(INFO, "Renaming named seasons...")
 	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
 	for _, v := range series.namedSeasons {
 		info := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
 		info.Rename()
 	}
-	log.Println(INFO, "Renaming single season no movies")
+	log.Println(INFO, "Done renaming named seasons.")
+	log.Println(INFO, "Renaming single season no movies...")
 	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
 	for _, v := range series.singleSeasonNoMovies {
 		info := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
 		info.Rename()
 	}
-	log.Println(INFO, "Renaming single season with movies")
+	log.Println(INFO, "Done renaming single season no movies.")
+	log.Println(INFO, "Renaming single season with movies...")
 	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
 	for _, v := range series.singleSeasonWithMovies {
 		info := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
 		info.Rename()
 	}
-	log.Println(INFO, "Renaming multiple season no movies")
+	log.Println(INFO, "Done renaming single season with movies.")
+	log.Println(INFO, "Renaming multiple season no movies...")
 	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
 	for _, v := range series.multipleSeasonNoMovies {
 		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
 		info.Rename()
 	}
-	log.Println(INFO, "Renaming multiple season with movies")
+	log.Println(INFO, "Done renaming multiple season no movies.")
+	log.Println(INFO, "Renaming multiple season with movies...")
 	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
 	for _, v := range series.multipleSeasonWithMovies {
 		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
 		info.Rename()
 	}
+	log.Println(INFO, "Done renaming multiple season with movies.")
 }
 
 func (movie *Movies) LogEntries() {

--- a/media_files.go
+++ b/media_files.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sync"
 )
 
 type MediaFiles interface {
@@ -102,7 +103,10 @@ func (series *Series) SplitByType(entries []string) {
 	}
 }
 
-func (movie *Movies) LogEntries() {
+func (movie *Movies) LogEntries(wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
 	log.Println(INFO, "categorized movies: ")
 	log.Println(INFO, "standalone: ")
 	for _, v := range movie.standalone {
@@ -114,7 +118,10 @@ func (movie *Movies) LogEntries() {
 	}
 }
 
-func (series *Series) LogEntries() {
+func (series *Series) LogEntries(wg *sync.WaitGroup) {
+	wg.Add(1)
+	defer wg.Done()
+
 	log.Println(INFO, "categorized series: ")
 	log.Println(INFO, "named seasons: ")
 	for _, v := range series.namedSeasons {

--- a/media_files.go
+++ b/media_files.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -17,7 +18,6 @@ type Movies struct {
 	standalone []string
 	movieSet   []string
 }
-
 const (
 	STANDALONE = "standalone"
 	MOVIE_SET  = "movieSet"
@@ -30,7 +30,6 @@ type Series struct {
 	multipleSeasonNoMovies   []string
 	multipleSeasonWithMovies []string
 }
-
 const (
 	NAMED_SEASONS               = "namedSeasons"
 	SINGLE_SEASON_NO_MOVIES     = "singleSeasonNoMovies"
@@ -115,38 +114,38 @@ func (series *Series) SplitByType(entries []string) error {
 }
 
 func (movie *Movies) LogEntries() {
-	fmt.Println("categorized movies: ")
-	fmt.Println("standalone: ")
+	log.Println(INFO, "categorized movies: ")
+	log.Println(INFO, "standalone: ")
 	for _, v := range movie.standalone {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
-	fmt.Println("movie set: ")
+	log.Println(INFO, "movie set: ")
 	for _, v := range movie.movieSet {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
 }
 
 func (series *Series) LogEntries() {
-	fmt.Println("categorized series: ")
-	fmt.Println("named seasons: ")
+	log.Println(INFO, "categorized series: ")
+	log.Println(INFO, "named seasons: ")
 	for _, v := range series.namedSeasons {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
-	fmt.Println("single season no movies: ")
+	log.Println(INFO, "single season no movies: ")
 	for _, v := range series.singleSeasonNoMovies {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
-	fmt.Println("single season with movies: ")
+	log.Println(INFO, "single season with movies: ")
 	for _, v := range series.singleSeasonWithMovies {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
-	fmt.Println("multiple season no movies: ")
+	log.Println(INFO, "multiple season no movies: ")
 	for _, v := range series.multipleSeasonNoMovies {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
-	fmt.Println("multiple season with movies: ")
+	log.Println(INFO, "multiple season with movies: ")
 	for _, v := range series.multipleSeasonWithMovies {
-		fmt.Println("\t", v)
+		log.Println(INFO, "\t", v)
 	}
 }
 

--- a/media_files.go
+++ b/media_files.go
@@ -40,7 +40,12 @@ const (
 
 func (movie *Movies) SplitByType(entries []string) {
 	for _, movieEntry := range entries {
-		files, _ := os.ReadDir(movieEntry)
+		files, err := os.ReadDir(movieEntry)
+		if err != nil {
+			log.Println(ERROR, "error reading movie entry:", movieEntry)
+			log.Println(ERROR, "skipping categorizing entry:", movieEntry)
+			continue
+		}
 
 		extrasPattern := regexp.MustCompile(`^(?i)specials?|extras?|trailers?`)
 
@@ -59,7 +64,12 @@ func (movie *Movies) SplitByType(entries []string) {
 
 func (series *Series) SplitByType(entries []string) {
 	for _, seriesEntry := range entries {
-		files, _ := os.ReadDir(seriesEntry)
+		files, err := os.ReadDir(seriesEntry)
+		if err != nil {
+			log.Println(ERROR, "error reading series entry:", seriesEntry)
+			log.Println(ERROR, "skipping categorizing entry:", seriesEntry)
+			continue
+		}
 		
 		namedSeasonsPattern := regexp.MustCompile(`^\d+\.\s+(.*)$`)
 		seasonalPattern := regexp.MustCompile(`^(?i)season\s+(\d+)`)
@@ -141,21 +151,15 @@ func (series *Series) LogEntries() {
 func (movies *Movies) RenameEntries(options Flags) error {
 	log.Println(INFO, "Renaming standalone movies")
 	for _, v := range movies.standalone {
-		info, err := MovieRenamePrereqs(v, STANDALONE)
-		if err != nil { return err }
-	
-		err = info.Rename()
-		if err != nil { return err }
+		info := MovieRenamePrereqs(v, STANDALONE)
+		info.Rename()
 	}
 	fmt.Println()
 
 	log.Println(INFO, "Renaming movie set")
 	for _, v := range movies.movieSet {
-		info, err := MovieRenamePrereqs(v, MOVIE_SET)
-		if err != nil { return err }
-
-		err = info.Rename()
-		if err != nil { return err }
+		info := MovieRenamePrereqs(v, MOVIE_SET)
+		info.Rename()
 	}
 	fmt.Println()
 
@@ -166,75 +170,40 @@ func (series *Series) RenameEntries(options Flags) error {
 	log.Println(INFO, "Renaming named seasons")
 	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
 	for _, v := range series.namedSeasons {
-		info, err := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
-		if err != nil {
-			return err
-		}
-
-		err = info.Rename()
-		if err != nil {
-			return err
-		}
+		info := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
+		info.Rename()
 	}
 	fmt.Println()
 
 	log.Println(INFO, "Renaming single season no movies")
 	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
 	for _, v := range series.singleSeasonNoMovies {
-		info, err := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
-		if err != nil {
-			return err
-		}
-
-		err = info.Rename()
-		if err != nil {
-			return err
-		}
+		info := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
+		info.Rename()
 	}
 	fmt.Println()
 
 	log.Println(INFO, "Renaming single season with movies")
 	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
 	for _, v := range series.singleSeasonWithMovies {
-		info, err := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
-		if err != nil {
-			return err
-		}
-
-		err = info.Rename()
-		if err != nil {
-			return err
-		}
+		info := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
+		info.Rename()
 	}
 	fmt.Println()
 
 	log.Println(INFO, "Renaming multiple season no movies")
 	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
 	for _, v := range series.multipleSeasonNoMovies {
-		info, err := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
-		if err != nil {
-			return err
-		}
-
-		err = info.Rename()
-		if err != nil {
-			return err
-		}
+		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
+		info.Rename()
 	}
 	fmt.Println()
 
 	log.Println(INFO, "Renaming multiple season with movies")
 	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
 	for _, v := range series.multipleSeasonWithMovies {
-		info, err := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
-		if err != nil {
-			return err
-		}
-
-		err = info.Rename()
-		if err != nil {
-			return err
-		}
+		info := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
+		info.Rename()
 	}
 	fmt.Println()
 

--- a/media_files.go
+++ b/media_files.go
@@ -17,9 +17,10 @@ type Movies struct {
 	standalone []string
 	movieSet   []string
 }
+
 const (
 	STANDALONE = "standalone"
-	MOVIE_SET   = "movieSet"
+	MOVIE_SET  = "movieSet"
 )
 
 type Series struct {
@@ -29,11 +30,12 @@ type Series struct {
 	multipleSeasonNoMovies   []string
 	multipleSeasonWithMovies []string
 }
+
 const (
-	NAMED_SEASONS             = "namedSeasons"
-	SINGLE_SEASON_NO_MOVIES   = "singleSeasonNoMovies"
-	SINGLE_SEASON_WITH_MOVIES = "singleSeasonWithMovies"
-	MULTIPLE_SEASON_NO_MOVIES = "multipleSeasonNoMovies"
+	NAMED_SEASONS               = "namedSeasons"
+	SINGLE_SEASON_NO_MOVIES     = "singleSeasonNoMovies"
+	SINGLE_SEASON_WITH_MOVIES   = "singleSeasonWithMovies"
+	MULTIPLE_SEASON_NO_MOVIES   = "multipleSeasonNoMovies"
 	MULTIPLE_SEASON_WITH_MOVIES = "multipleSeasonWithMovies"
 )
 
@@ -148,39 +150,51 @@ func (series *Series) LogEntries() {
 	}
 }
 
-func (movies *Movies) RenameEntries(options AdditionalOptions) error{
+func (movies *Movies) RenameEntries(options Flags) error {
 	fmt.Println("Renaming standalone movies")
 	for _, v := range movies.standalone {
 		info, err := MovieRenamePrereqs(v, STANDALONE)
-		if err != nil { panic(err) }
+		if err != nil {
+			panic(err)
+		}
 
 		err = info.Rename()
-		if err != nil { panic(err) }
+		if err != nil {
+			panic(err)
+		}
 	}
 	fmt.Println()
 
 	fmt.Println("Renaming movie set")
 	for _, v := range movies.movieSet {
 		info, err := MovieRenamePrereqs(v, MOVIE_SET)
-		if err != nil { panic(err) }
+		if err != nil {
+			panic(err)
+		}
 
 		err = info.Rename()
-		if err != nil { panic(err) }
+		if err != nil {
+			panic(err)
+		}
 	}
 	fmt.Println()
 
 	return nil
 }
 
-func (series *Series) RenameEntries(options AdditionalOptions) error{
+func (series *Series) RenameEntries(options Flags) error {
 	fmt.Println("Renaming named seasons")
 	namedSeasonOptions := PromptOptionalFlags(options, "all named seasons", 0)
 	for _, v := range series.namedSeasons {
 		info, err := SeriesRenamePrereqs(v, NAMED_SEASONS, namedSeasonOptions)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 
 		err = info.Rename()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Println()
 
@@ -188,10 +202,14 @@ func (series *Series) RenameEntries(options AdditionalOptions) error{
 	ssnmOptions := PromptOptionalFlags(options, "all single season with no movies", 0)
 	for _, v := range series.singleSeasonNoMovies {
 		info, err := SeriesRenamePrereqs(v, SINGLE_SEASON_NO_MOVIES, ssnmOptions)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 
 		err = info.Rename()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Println()
 
@@ -199,10 +217,14 @@ func (series *Series) RenameEntries(options AdditionalOptions) error{
 	sswmOptions := PromptOptionalFlags(options, "all single season with movies", 0)
 	for _, v := range series.singleSeasonWithMovies {
 		info, err := SeriesRenamePrereqs(v, SINGLE_SEASON_WITH_MOVIES, sswmOptions)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 
 		err = info.Rename()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Println()
 
@@ -210,10 +232,14 @@ func (series *Series) RenameEntries(options AdditionalOptions) error{
 	msnmOptions := PromptOptionalFlags(options, "all multiple season with no movies", 0)
 	for _, v := range series.multipleSeasonNoMovies {
 		info, err := SeriesRenamePrereqs(v, MULTIPLE_SEASON_NO_MOVIES, msnmOptions)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 
 		err = info.Rename()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Println()
 
@@ -221,10 +247,14 @@ func (series *Series) RenameEntries(options AdditionalOptions) error{
 	mswmOptions := PromptOptionalFlags(options, "all multiple season with movies", 0)
 	for _, v := range series.multipleSeasonWithMovies {
 		info, err := SeriesRenamePrereqs(v, MULTIPLE_SEASON_WITH_MOVIES, mswmOptions)
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 
 		err = info.Rename()
-		if err != nil { return err }
+		if err != nil {
+			return err
+		}
 	}
 	fmt.Println()
 

--- a/parse_args.go
+++ b/parse_args.go
@@ -16,6 +16,8 @@ type Arg struct {
 }
 
 func TokenizeArgs(args []string) ([]Arg, error) {
+	defer timer("TokenizeArgs")()
+
 	var tokenizedArgs []Arg
 	isValidName := map[string]bool{
 		// commands
@@ -107,6 +109,8 @@ func newArgs() Args {
 }
 
 func (args *Args) Log() {
+	defer timer("Args.Log")()
+	
 	if len(args.root) > 0 {
 		log.Println(INFO, "root directories: ")
 		for _, root := range args.root {
@@ -144,6 +148,8 @@ func (args *Args) Log() {
 }
 
 func ParseArgs(args []Arg) (Args, error) {
+	defer timer("ParseArgs")()
+
 	if len(args) < 1 {
 		return Args{}, fmt.Errorf("not enough arguments: '%v'", args)
 	}

--- a/parse_args.go
+++ b/parse_args.go
@@ -18,14 +18,14 @@ func TokenizeArgs(args []string) ([]Arg, error) {
 	var tokenizedArgs []Arg
 	isValidName := map[string]bool{
 		// commands
-		"root":              true,
-		"series":            true,
-		"movies":            true,
+		"root":   true,
+		"series": true,
+		"movies": true,
 		// switches
-		"--help":            true,
-		"-h":                true,
-		"--version":         true,
-		"-v":                true,
+		"--help":    true,
+		"-h":        true,
+		"--version": true,
+		"-v":        true,
 		// flags
 		"--options":         true,
 		"-o":                true,
@@ -78,9 +78,9 @@ type Args struct {
 	root    []string
 	series  []string
 	movies  []string
-	options AdditionalOptions
+	options Flags
 }
-type AdditionalOptions struct {
+type Flags struct {
 	keepEpNums    Option[bool]
 	startingEpNum Option[int]
 	hasSeason0    Option[bool]
@@ -92,7 +92,7 @@ func newArgs() Args {
 		root:   make([]string, 0),
 		series: make([]string, 0),
 		movies: make([]string, 0),
-		options: AdditionalOptions{
+		options: Flags{
 			hasSeason0:    none[bool](),
 			keepEpNums:    none[bool](),
 			startingEpNum: none[int](),

--- a/parse_args.go
+++ b/parse_args.go
@@ -52,6 +52,10 @@ func TokenizeArgs(args []string) ([]Arg, error) {
 			} else {
 				return nil, fmt.Errorf("start with invalid flag: '%s'", arg)
 			}
+			if i == len(args)-1 {
+				newArg.value = value
+				tokenizedArgs = append(tokenizedArgs, newArg)
+			}
 		} else {
 			if isValidName[arg] {
 				newArg.value = value
@@ -103,7 +107,7 @@ func newArgs() Args {
 
 func ParseArgs(args []Arg) (Args, error) {
 	if len(args) < 1 {
-		return Args{}, fmt.Errorf("not enough arguments")
+		return Args{}, fmt.Errorf("not enough arguments: '%v'", args)
 	}
 
 	directoryArgs := map[string]bool{

--- a/parse_args.go
+++ b/parse_args.go
@@ -127,11 +127,11 @@ func ParseArgs(args []Arg) (Args, error) {
 			} else if len(args) > i+1 {
 				Help(args[i+1].name)
 			}
-			return Args{}, fmt.Errorf("safe exit")
+			return Args{}, SafeErrorF("safe exit")
 
 		} else if arg.name == "--version" || arg.name == "-v" {
 			Version(version)
-			return Args{}, fmt.Errorf("safe exit")
+			return Args{}, SafeErrorF("safe exit")
 
 		} else if directoryArgs[arg.name] {
 			// no value after flag / flag after flag

--- a/parse_args.go
+++ b/parse_args.go
@@ -127,7 +127,7 @@ func ParseArgs(args []Arg) (Args, error) {
 	for i, arg := range args {
 		if arg.name == "--help" || arg.name == "-h" {
 			if len(args) <= i+1 {
-				Help("")
+				Help(arg.value)
 			} else if len(args) > i+1 {
 				Help(args[i+1].name)
 			}

--- a/parse_args.go
+++ b/parse_args.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -102,6 +103,43 @@ func newArgs() Args {
 			startingEpNum: none[int](),
 			namingScheme:  none[string](),
 		},
+	}
+}
+
+func (args *Args) Log() {
+	if len(args.root) > 0 {
+		log.Println(INFO, "root directories: ")
+		for _, root := range args.root {
+			log.Println(INFO, "\t", root)
+		}
+	}
+	if len(args.series) > 0 {
+		log.Println(INFO, "series sources:")
+		for _, series := range args.series {
+			log.Println(INFO, "\t", series)
+		}
+	}
+	if len(args.movies) > 0 {
+		log.Println(INFO, "movies sources:")
+		for _, movie := range args.movies {
+			log.Println(INFO, "\t", movie)
+		}
+	}
+	ken, err := args.options.keepEpNums.Get()
+	if err == nil {
+		log.Println(INFO, "keep episode numbers: ", ken)
+	}
+	sen, err := args.options.startingEpNum.Get()
+	if err == nil {
+		log.Println(INFO, "starting episode number: ", sen)
+	}
+	s0, err := args.options.hasSeason0.Get()
+	if err == nil {
+		log.Println(INFO, "has season 0: ", s0)
+	}
+	ns, err := args.options.namingScheme.Get()
+	if err == nil {
+		log.Println(INFO, "naming scheme: ", ns)
 	}
 }
 

--- a/rename.go
+++ b/rename.go
@@ -135,12 +135,12 @@ func (info *SeriesInfo) Rename() {
 
 			_, err = os.Stat(newName)
 			if err == nil {
-				log.Println(WARN, "renaming", filepath.Base(file), "to", filepath.Base(newName), "failed: file already exists; skipping renaming:", file)
+				log.Println(WARN, "file already exists: renaming", filepath.Base(file), "to", filepath.Base(newName), "failed; skipping renaming:", file)
 				continue
 			} else if os.IsNotExist(err) {
 				err = os.Rename(file, newName)
 				if err != nil {
-					log.Println(WARN, "error renaming", filepath.Base(file), "to", filepath.Base(newName), ":", err, "; skipping renaming:", file)
+					log.Println(WARN, "renaming error:", err, "; skipping renaming:", file)
 					continue
 				}
 			} else {
@@ -183,7 +183,7 @@ func (info *SeriesInfo) Rename() {
 			// fmt.Println("old", info.path+"/"+movie+"/"+mediaFiles[0], "new", info.path+"/"+movie+"/"+newName)
 			err = os.Rename(info.path+"/"+movie+"/"+mediaFiles[0], info.path+"/"+movie+"/"+newName)
 			if err != nil {
-				log.Println(WARN, "error renaming", mediaFiles[0], "to", newName, ":", err, "; skipping renaming:", info.path+"/"+movie+"/"+mediaFiles[0])
+				log.Println(WARN, "renaming error:", err, "; skipping renaming:", info.path+"/"+movie+"/"+mediaFiles[0])
 				continue
 			}
 		}
@@ -204,12 +204,12 @@ func (info *MovieInfo) Rename() {
 		// fmt.Println("old", info.path+"/"+old_name, "new", info.path+"/"+newName)
 		_, err := os.Stat(info.path+"/"+newName)
 		if err == nil {
-			log.Println(WARN, "renaming", filepath.Base(old_name), "to", filepath.Base(newName), "failed: file already exists; skipping renaming:", info.path+"/"+old_name)
+			log.Println(WARN, "file already exists: renaming", filepath.Base(old_name), "to", filepath.Base(newName), "failed; skipping renaming:", info.path+"/"+old_name)
 			continue
 		} else if os.IsNotExist(err) {
 			err = os.Rename(info.path+"/"+old_name, info.path+"/"+newName)
 			if err != nil {
-				log.Println(WARN, "error renaming", filepath.Base(old_name), "to", filepath.Base(newName), ":", err, "; skipping renaming:", info.path+"/"+old_name)
+				log.Println(WARN, "renaming error:", err, "; skipping renaming:", info.path+"/"+old_name)
 				continue
 			}
 		} else {

--- a/rename.go
+++ b/rename.go
@@ -363,6 +363,7 @@ func GenerateNewName(namingScheme Option[string], season_pad int, season_num int
 				regex_pattern := strings.Trim(val, "'")
 				_, err := regexp.Compile(regex_pattern)
 				if err != nil {
+					log.Println(WARN, "invalid regex:", regex_pattern, "; using entire parent name:", parent_name, " instead in renaming:", abs_path, "using naming scheme:", scheme)	
 					return parent_name
 				}
 				sub_regexes := SplitRegexByPipe(regex_pattern)
@@ -373,7 +374,7 @@ func GenerateNewName(namingScheme Option[string], season_pad int, season_num int
 						return sub_match[1]
 					}
 				}
-				// did not find a substring match
+				log.Println(WARN, "no substring match found in regex:", regex_pattern, "; using entire parent name:", parent_name, " instead in renaming:", abs_path, "using naming scheme:", scheme)
 				return parent_name
 
 			// <parent: 1>

--- a/rename.go
+++ b/rename.go
@@ -19,7 +19,7 @@ type SeriesInfo struct {
 	seriesType string
 	seasons    map[int]string
 	movies     []string
-	options    AdditionalOptions
+	options    Flags
 }
 
 type MovieInfo struct {

--- a/rename.go
+++ b/rename.go
@@ -50,8 +50,7 @@ func (info *SeriesInfo) Rename() {
 			return nil
 		})
 		if err != nil {
-			log.Println(ERROR, "error reading media files under:", seasonPath)
-			log.Println(ERROR, "skipping renaming all episodes in:", seasonPath)
+			log.Println(WARN, "error reading media files:", err, "; skipping renaming all episodes in:", seasonPath)
 			continue
 		}
 		sort.Sort(FilenameSort(mediaFiles))
@@ -88,8 +87,7 @@ func (info *SeriesInfo) Rename() {
 			for i, file := range mediaFiles {
 				epNum, err = ReadEpisodeNum(file)
 				if err != nil {
-					log.Println(WARN, "error reading episode number from:", file)
-					log.Println(WARN, "skipping renaming:", file)
+					log.Println(WARN, "error reading episode number from", file, ":", err, "; skipping renaming")
 					// don't include this episode in renaming
 					mediaFiles = append(mediaFiles[:i], mediaFiles[i+1:]...)
 				}
@@ -137,18 +135,16 @@ func (info *SeriesInfo) Rename() {
 
 			_, err = os.Stat(newName)
 			if err == nil {
-				log.Println(WARN, "renaming", filepath.Base(file), "to", filepath.Base(newName), "failed: file already exists")
-				log.Println(WARN, "skipping renaming:", file)
+				log.Println(WARN, "renaming", filepath.Base(file), "to", filepath.Base(newName), "failed: file already exists; skipping renaming:", file)
 				continue
 			} else if os.IsNotExist(err) {
 				err = os.Rename(file, newName)
 				if err != nil {
-					log.Println(ERROR, "error renaming", filepath.Base(file), "to", filepath.Base(newName), ":", err)
-					log.Println(ERROR, "skipping renaming:", file)
+					log.Println(WARN, "error renaming", filepath.Base(file), "to", filepath.Base(newName), ":", err, "; skipping renaming:", file)
 					continue
 				}
 			} else {
-				log.Println(ERROR, "unexpected error when checking if file exists before renaming:", err)
+				log.Println(WARN, "unexpected error when checking if file exists before renaming:", err)
 				continue
 			}
 		}
@@ -159,8 +155,7 @@ func (info *SeriesInfo) Rename() {
 		for _, movie := range info.movies {
 			files, err := os.ReadDir(info.path + "/" + movie)
 			if err != nil {
-				log.Println(ERROR, "error reading media files under:", info.path+"/"+movie)
-				log.Println(ERROR, "skipping renaming:", info.path+"/"+movie)
+				log.Println(WARN, "error reading media files under ", info.path+"/"+movie, ":", err, "; skipping renaming")
 				continue
 			}
 
@@ -175,12 +170,10 @@ func (info *SeriesInfo) Rename() {
 			}
 
 			if len(mediaFiles) > 1 {
-				log.Println(WARN, "multiple media files found in supposed movie directory under series:", info.path+"/"+movie)
-				log.Println(WARN, "skipping renaming:", info.path+"/"+movie)
+				log.Println(WARN, "multiple media files found in supposed movie directory under series:", info.path+"/"+movie, "; skipping renaming")
 				continue
 			} else if len(mediaFiles) == 0 {
-				log.Println(WARN, "no media files found in:", info.path+"/"+movie)
-				log.Println(WARN, "skipping renaming:", info.path+"/"+movie)
+				log.Println(WARN, "no media files found in:", info.path+"/"+movie, "; skipping renaming")
 				continue
 			}
 
@@ -190,8 +183,7 @@ func (info *SeriesInfo) Rename() {
 			// fmt.Println("old", info.path+"/"+movie+"/"+mediaFiles[0], "new", info.path+"/"+movie+"/"+newName)
 			err = os.Rename(info.path+"/"+movie+"/"+mediaFiles[0], info.path+"/"+movie+"/"+newName)
 			if err != nil {
-				log.Println(ERROR, "error renaming", mediaFiles[0], "to", newName, ":", err)
-				log.Println(ERROR, "skipping renaming:", info.path+"/"+movie)
+				log.Println(WARN, "error renaming", mediaFiles[0], "to", newName, ":", err, "; skipping renaming:", info.path+"/"+movie+"/"+mediaFiles[0])
 				continue
 			}
 		}
@@ -212,18 +204,16 @@ func (info *MovieInfo) Rename() {
 		// fmt.Println("old", info.path+"/"+old_name, "new", info.path+"/"+newName)
 		_, err := os.Stat(info.path+"/"+newName)
 		if err == nil {
-			log.Println(WARN, "renaming", filepath.Base(old_name), "to", filepath.Base(newName), "failed: file already exists")
-			log.Println(WARN, "skipping renaming:", info.path+"/"+old_name)
+			log.Println(WARN, "renaming", filepath.Base(old_name), "to", filepath.Base(newName), "failed: file already exists; skipping renaming:", info.path+"/"+old_name)
 			continue
 		} else if os.IsNotExist(err) {
 			err = os.Rename(info.path+"/"+old_name, info.path+"/"+newName)
 			if err != nil {
-				log.Println(ERROR, "error renaming", filepath.Base(old_name), "to", filepath.Base(newName), ":", err)
-				log.Println(ERROR, "skipping renaming:", info.path+"/"+old_name)
+				log.Println(WARN, "error renaming", filepath.Base(old_name), "to", filepath.Base(newName), ":", err, "; skipping renaming:", info.path+"/"+old_name)
 				continue
 			}
 		} else {
-			log.Println(ERROR, "unexpected error when checking if file exists before renaming:", err)
+			log.Println(WARN, "unexpected error when checking if file exists before renaming:", err)
 			continue
 		}
 	}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -200,12 +200,11 @@ func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]str
 		}
 
 		if hasSeason0 {
-			if seasons[0] != "" {
-				log.Println(WARN, "multiple specials/extras directories found [", seasons[0], ",", subdir.Name(), "]; skipping renaming entry:", path )
-				return make(map[int]string), make([]string, 0)
-			}
-
 			if extrasPattern.MatchString(subdir.Name()) {
+				if seasons[0] != "" {
+					log.Println(WARN, "multiple specials/extras directories found [", seasons[0], ",", subdir.Name(), "]; skipping renaming entry:", path )
+					return make(map[int]string), make([]string, 0)
+				}
 				seasons[0] = subdir.Name()
 				continue
 			}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -10,13 +10,13 @@ import (
 	"strings"
 )
 
-func SeriesRenamePrereqs(path string, sType string, options AdditionalOptions) (SeriesInfo, error) {
+func SeriesRenamePrereqs(path string, sType string, options Flags) (SeriesInfo, error) {
 	// Get prerequsite info for renaming series
 	isValidType := map[string]bool{
 		SINGLE_SEASON_NO_MOVIES:     true,
 		SINGLE_SEASON_WITH_MOVIES:   true,
-		NAMED_SEASONS:             true,
-		MULTIPLE_SEASON_NO_MOVIES: true,
+		NAMED_SEASONS:               true,
+		MULTIPLE_SEASON_NO_MOVIES:   true,
 		MULTIPLE_SEASON_WITH_MOVIES: true,
 	}
 	if !isValidType[sType] {
@@ -55,7 +55,7 @@ func SeriesRenamePrereqs(path string, sType string, options AdditionalOptions) (
 // PromptOptionalFlags prompts the user for additional options.
 //
 // params:
-//   - options AdditionalOptions: Additional options for the prompt.
+//   - options Flags: flags for the prompt.
 //   - path string: The path of the file.
 //   - level int8: The level of the prompt.
 //
@@ -65,8 +65,8 @@ func SeriesRenamePrereqs(path string, sType string, options AdditionalOptions) (
 //   - level 2: per series season level
 //
 // return:
-//   - AdditionalOptions: The additional options for the prompt.
-func PromptOptionalFlags(options AdditionalOptions, path string, level int8) AdditionalOptions {
+//   - Flags: changed/unchanged flags for the prompt.
+func PromptOptionalFlags(options Flags, path string, level int8) Flags {
 	defaultKEN := some[bool](false)
 	defaultSEN := some[int](1)
 	defaultS0 := some[bool](false)

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -184,7 +184,7 @@ func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]str
 
 	subdirs, err := os.ReadDir(path)
 	if err != nil {
-		log.Println(WARN, "there was an error reading series entry:", err, "; skipping renaming entry:", path)
+		log.Println(WARN, "error reading series entry:", err, "; skipping renaming entry:", path)
 		return seasons, movies
 	}
 

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -13,11 +13,11 @@ import (
 func SeriesRenamePrereqs(path string, sType string, options AdditionalOptions) (SeriesInfo, error) {
 	// Get prerequsite info for renaming series
 	isValidType := map[string]bool{
-		"singleSeasonNoMovies":     true,
-		"singleSeasonWithMovies":   true,
-		"namedSeasons":             true,
-		"multipleSeasonNoMovies":   true,
-		"multipleSeasonWithMovies": true,
+		SINGLE_SEASON_NO_MOVIES:     true,
+		SINGLE_SEASON_WITH_MOVIES:   true,
+		NAMED_SEASONS:             true,
+		MULTIPLE_SEASON_NO_MOVIES: true,
+		MULTIPLE_SEASON_WITH_MOVIES: true,
 	}
 	if !isValidType[sType] {
 		return SeriesInfo{}, fmt.Errorf("unknown series type: %s", sType)
@@ -231,9 +231,9 @@ func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]str
 			}
 		}
 
-		if sType == "singleSeasonNoMovies" {
+		if sType == SINGLE_SEASON_NO_MOVIES {
 			continue
-		} else if sType == "singleSeasonWithMovies" {
+		} else if sType == SINGLE_SEASON_WITH_MOVIES {
 			if extrasPattern.MatchString(subdir.Name()) {
 				continue
 			} else {
@@ -244,9 +244,9 @@ func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]str
 
 		// Get season number from subdir name
 		var seasonNamePattern *regexp.Regexp
-		if sType == "namedSeasons" {
+		if sType == NAMED_SEASONS {
 			seasonNamePattern = regexp.MustCompile(`^(\d+)\..*$`)
-		} else if sType == "multipleSeasonNoMovies" || sType == "multipleSeasonWithMovies" {
+		} else if sType == MULTIPLE_SEASON_NO_MOVIES || sType == MULTIPLE_SEASON_WITH_MOVIES {
 			seasonNamePattern = regexp.MustCompile(`^(?i)season\s+(\d+).*$`)
 		} else {
 			return nil, nil, fmt.Errorf("unknown series type: %s; series type must be one of 'namedSeasons', 'multipleSeasonNoMovies', 'multipleSeasonWithMovies'", sType)
@@ -257,7 +257,7 @@ func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]str
 
 		readSeasonNum := seasonNamePattern.FindStringSubmatch(subdir.Name())
 		if readSeasonNum == nil {
-			if sType == "multipleSeasonWithMovies" {
+			if sType == MULTIPLE_SEASON_WITH_MOVIES {
 				if extrasPattern.MatchString(subdir.Name()) {
 					continue
 				} else {
@@ -294,7 +294,7 @@ func MovieRenamePrereqs(path string, mType string) (MovieInfo, error) {
 	extrasPattern := regexp.MustCompile(`^(?i)specials?|extras?|trailers?|ova`)
 
 	for _, subdir := range subdirs {
-		if mType == "standalone" {
+		if mType == STANDALONE {
 			if subdir.IsDir() && extrasPattern.MatchString(subdir.Name()) {
 				continue
 			}
@@ -313,7 +313,7 @@ func MovieRenamePrereqs(path string, mType string) (MovieInfo, error) {
 			continue
 		}
 
-		if mType == "movieSet" {
+		if mType == MOVIE_SET {
 			if extrasPattern.MatchString(subdir.Name()) {
 				continue
 			}

--- a/rename_prereq.go
+++ b/rename_prereq.go
@@ -11,6 +11,10 @@ import (
 	"strings"
 )
 
+// SeriesRenamePrereqs returns a SeriesInfo with information needed to rename a series entry.
+//	path: The path of the series.
+//	sType: The type of series.
+//	options: Flags for the prompt.
 func SeriesRenamePrereqs(path string, sType string, options Flags) (SeriesInfo) {
 	// if flags are none aka user inputted var, ask for user input again
 	options = PromptOptionalFlags(options, path, 1)
@@ -178,6 +182,10 @@ func PromptOptionalFlags(options Flags, path string, level int8) Flags {
 	return options
 }
 
+// FetchSeriesContent retrieves the season directories and movie directories from the given series entry.
+//	path: The path of the series entry.
+//	sType: The type of series.
+//	hasSeason0: Whether the series has a season 0 directory.
 func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]string, []string) {
 	seasons := make(map[int]string)
 	movies := make([]string, 0)
@@ -252,6 +260,9 @@ func FetchSeriesContent(path string, sType string, hasSeason0 bool) (map[int]str
 	return seasons, movies
 }
 
+// MovieRenamePrereqs returns a MovieInfo with information needed to rename a movie entry.
+//	path: The path of the movie.
+//	mType: The type of movie.
 func MovieRenamePrereqs(path string, mType string) (MovieInfo) {
 	info := MovieInfo{
 		path:      path,

--- a/utils.go
+++ b/utils.go
@@ -2,13 +2,14 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
-	"unicode"
 	"time"
+	"unicode"
 )
 
 func IsMediaFile(file string) bool {
@@ -276,7 +277,7 @@ func (s SafeError) Error() string {
 func timer(name string) func() {
     start := time.Now()
     return func() {
-        fmt.Printf("%s took %v\n", name, time.Since(start))
+        log.Printf("%s %s took %v\n", TIME, name, time.Since(start))
     }
 }
 
@@ -286,4 +287,5 @@ const (
 	WARN = "\033[93m[WARN]\033[0m "		// yellow
 	ERROR = "\033[91m[ERROR]\033[0m "	// red
 	FATAL = "\033[91m[FATAL]\033[0m "	// red
+	TIME = "\033[94m[TIME]\033[0m "		// blue
 )

--- a/utils.go
+++ b/utils.go
@@ -250,3 +250,17 @@ func ParentN(path string, n int) string {
 	}
 	return filepath.Base(path)
 }
+
+type SafeError struct {
+	safe error
+}
+
+func SafeErrorF(s string, args ...interface{}) SafeError {
+	return SafeError{
+		safe: fmt.Errorf(s, args...),
+	}
+}
+
+func (s SafeError) Error() string {
+	return s.safe.Error()
+}

--- a/utils.go
+++ b/utils.go
@@ -180,20 +180,17 @@ func HasOnlyOneMatchGroup(s string) bool {
 	openingCount := 0
 	closingCount := 0
 	matchGroupCount := 0
-	depth := 0
 
 	for _, c := range s {
-		if c == '(' && depth == 0 {
+		if c == '(' {
 			openingCount++
-			depth++
-		} else if c == ')' && depth == 1 {
+		} else if c == ')' && closingCount < openingCount {
 			closingCount++
 			matchGroupCount++
-			depth--
 		}
 	}
 
-	return matchGroupCount == 1
+	return matchGroupCount == 1 || matchGroupCount == 0
 }
 
 // returns the nth parent directory

--- a/utils.go
+++ b/utils.go
@@ -1,3 +1,5 @@
+// utils.go
+// contains helper functions that are general purpose
 package main
 
 import (
@@ -12,6 +14,9 @@ import (
 	"unicode"
 )
 
+// checks if a file is a media file through checking the file extension
+//
+// current media extensions: .mkv, .mp4, .avi, .mov, .webm, .ts
 func IsMediaFile(file string) bool {
 	// TODO: find a better way to identify media files
 	mediaExtensions := map[string]bool{
@@ -25,6 +30,8 @@ func IsMediaFile(file string) bool {
 	return mediaExtensions[filepath.Ext(file)]
 }
 
+// checks if a series entry contains a movie subdir through checking
+// if the subdir name is not a season or an extras/specials subdir
 func HasMovie(path string) (bool, error) {
 	files, err := os.ReadDir(path)
 	if err != nil {
@@ -45,50 +52,9 @@ func HasMovie(path string) (bool, error) {
 	return false, nil
 }
 
-// valid filename substring formats
+// natural sorting of filenames
 //
-// case insensitive
-// can have spaces between season part and episode part (`S01 x E02`, `S01. E02`, `S01 _E02`, `S01 E02`)
-// but can't have spaces between episode/season indicator and episode/season number.
-// separators like `-` or `_` are allowed and can be repeated (`S01---E02`, `S01 __ E02`, `S01 xxE02`, `S01    E02`)
-//
-// S01E02 | S03.E04 | S05_E06 | S07-E08 | S09xE10 | S11 E12
-//
-// 01.02 | 03_04 | 05-06 | 07x08 | 09 10
-//
-// Episode 01 | Episode02 | EP03 | EP-04 | E_05 | EP.06
-func ReadEpisodeNum(file string) (int, error) {
-
-	// https://regex-vis.com/?r=s%5Cd%2B%5Cs*%28%3F%3Ax*%7C_*%7C-*%7C%5B.%5D*%29%5Cs*e%28%5Cd%2B%29%7C%5Cd%2B%5Cs*%28%3F%3Ax%2B%7C_%2B%7C-%2B%7C%5B.%5D%2B%29%5Cs*%28%5Cd%2B%29%7Cep%3F%28%3F%3Aisode%29%3F%5Cs*%28%3F%3A_%2B%7C-%2B%7C%5B.%5D%2B%29%5Cs*%28%5Cd%2B%29&e=0
-	// match_id:											 			    [1]				   				   [2]									       [3]
-	// captured:                                             				vv                    			   vv                 						   vv
-	// substring:		                      s 01      x  _  -   .      e  02 | 03      x  _  -   .           04 |ep    isode          _  -   .           05
-	episodePattern := regexp.MustCompile(`(?i)s\d+\s*(?:x*|_*|-*|[.]*)\s*e(\d+)|\d+\s*(?:x+|_+|-+|[.]+)\s*(\d+)|ep?(?:isode)?\s*(?:_+|-+|[.]+)\s*(\d+)`)
-	match := episodePattern.FindStringSubmatch(file)
-	if len(match) > 1 {
-		epNumStr := ""
-		for _, v := range match[1:] {
-			if v != "" && epNumStr != "" {
-				return 0, fmt.Errorf("multiple episode numbers found in %s: '%s', '%s' and '%s'", file, match[1], match[2], match[3])
-			} else if v != "" {
-				epNumStr = v
-			}
-		}
-		if epNumStr == "" {
-			return 0, fmt.Errorf("could not find episode number in %s", file)
-		}
-
-		epNum, err := strconv.Atoi(epNumStr)
-		if err != nil {
-			return 0, err
-		}
-		return epNum, nil
-	} else {
-		return 0, fmt.Errorf("could not find episode number in %s", file)
-	}
-}
-
-// filename renaming
+// usage: sort.Sort(FilenameSort(slice of paths))
 type FilenameSort []string
 
 // implement sort.Interface (Len, Less, Swap)
@@ -149,6 +115,7 @@ func SplitFilename(filename string) []string {
 	return parts
 }
 
+// checks if a string is a valid number
 func IsNumeric(s string) bool {
 	_, err := strconv.Atoi(s)
 	return err == nil
@@ -175,6 +142,11 @@ func CleanTitle(title string) string {
 	return title
 }
 
+// splits a regex by outermost pipes
+//
+// example:
+//	`a|b|c|d|e` --> `a`, `b`, `c`, `d`, `e`
+//	`a|(b|c|d|e)` --> `a`, `(b|c|d|e)`
 func SplitRegexByPipe(s string) []string {
 	var parts []string
 	depth := 0
@@ -195,6 +167,15 @@ func SplitRegexByPipe(s string) []string {
 	return parts
 }
 
+// checks if a regex has only one match group
+//
+// note that this is usually called after SplitRegexByPipe so outermost pipes are removed first
+//
+// examples:
+//	`(a|b)` --> true
+//	`(a(b)a)` --> false
+//	`(a|b|c)` --> true
+//	`a` --> true
 func HasOnlyOneMatchGroup(s string) bool {
 	openingCount := 0
 	closingCount := 0
@@ -215,37 +196,12 @@ func HasOnlyOneMatchGroup(s string) bool {
 	return matchGroupCount == 1
 }
 
-func ParentTokenToInt(s string) (int, error) {
-	// lmao https://regex-vis.com/?r=%3Cparent%28-parent%29*%28%5Cs*%3A%5Cs*%28%28%5Cd+%5Cs*%2C%5Cs*%5Cd+%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
-	longForm := regexp.MustCompile(`<parent(-parent)*(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?\s*>`)
-	// lul https://regex-vis.com/?r=%3Cp%28-%5Cd%2B%29%3F%28%5Cs*%3A%5Cs*%28%28%5Cd%5Cs*%2C%5Cs*%5Cd%29%7C%28%27%5B%5E%27%5D*%27%29%29%29%3F%5Cs*%3E&e=0
-	shortForm := regexp.MustCompile(`<p(-\d+)?(\s*:\s*((\d+(\s*,\s*\d+)?)|('[^']*')))?\s*>`)
-
-	if longForm.MatchString(s) {
-		return strings.Count(s, "parent"), nil
-
-	} else if shortForm.MatchString(s) {
-		// only p
-		singleP := regexp.MustCompile(`p\s*[^-]:?`)
-		if singleP.MatchString(s) {
-			return 1, nil
-		}
-		// p-int
-		matchNum := regexp.MustCompile(`p-(\d+)`).FindStringSubmatch(s)
-		if len(matchNum) != 2 {
-			return 0, fmt.Errorf("invalid parent token: %s", s)
-		}
-		num, err := strconv.Atoi(matchNum[1])
-		if err != nil {
-			return 0, err
-		}
-		return num, nil
-
-	} else {
-		return 0, fmt.Errorf("invalid parent token: %s", s)
-	}
-}
-
+// returns the nth parent directory
+//
+// examples:
+// 	ParentN("a/b/c", 1) --> "a/b"
+// 	ParentN("a/b/c", 2) --> "a"
+// 	ParentN("a/b/c", 3) --> ""
 func ParentN(path string, n int) string {
 	for i := 0; i < n; i++ {
 		path = filepath.Dir(path)
@@ -253,16 +209,21 @@ func ParentN(path string, n int) string {
 	return filepath.Base(path)
 }
 
+// specifically for exiting safely when user passed these switches:
+//	`--help, -h`
+//	`--version, -v`
 type SafeError struct {
 	safe error
 }
 
+// acts exactly like fmt.Errorf but returns a SafeError instead of error
 func SafeErrorF(s string, args ...interface{}) SafeError {
 	return SafeError{
 		safe: fmt.Errorf(s, args...),
 	}
 }
 
+// returns the underlying safe error as a string
 func (s SafeError) Error() string {
 	return s.safe.Error()
 }

--- a/utils.go
+++ b/utils.go
@@ -57,10 +57,11 @@ func HasMovie(path string) (bool, error) {
 // Episode 01 | Episode02 | EP03 | EP-04 | E_05 | EP.06
 func ReadEpisodeNum(file string) (int, error) {
 
-	// match_id:											 				 [1]				   					  [2]										  [3]
-	// captured:                                             				 vv                    					  vv                 						  vv
-	// substring:		                       s 01      x  _  -   .      e  02 | 03      x  _  -   .            e    04 |ep    isode          _  -   .           05
-	episodePattern := regexp.MustCompile(`(?i)s\d+\s*(?:x*|_*|-*|[.]*)\s*e(\d+)|\d+\s*(?:x+|_+|-+|[.]+|\s)\s*(?:e)?(\d+)|ep?(?:isode\s)?\s*(?:_+|-+|[.]+|\s?)\s*(\d+)`)
+	// https://regex-vis.com/?r=s%5Cd%2B%5Cs*%28%3F%3Ax*%7C_*%7C-*%7C%5B.%5D*%29%5Cs*e%28%5Cd%2B%29%7C%5Cd%2B%5Cs*%28%3F%3Ax%2B%7C_%2B%7C-%2B%7C%5B.%5D%2B%29%5Cs*%28%5Cd%2B%29%7Cep%3F%28%3F%3Aisode%29%3F%5Cs*%28%3F%3A_%2B%7C-%2B%7C%5B.%5D%2B%29%5Cs*%28%5Cd%2B%29&e=0
+	// match_id:											 			    [1]				   				   [2]									       [3]
+	// captured:                                             				vv                    			   vv                 						   vv
+	// substring:		                      s 01      x  _  -   .      e  02 | 03      x  _  -   .           04 |ep    isode          _  -   .           05
+	episodePattern := regexp.MustCompile(`(?i)s\d+\s*(?:x*|_*|-*|[.]*)\s*e(\d+)|\d+\s*(?:x+|_+|-+|[.]+)\s*(\d+)|ep?(?:isode)?\s*(?:_+|-+|[.]+)\s*(\d+)`)
 	match := episodePattern.FindStringSubmatch(file)
 	if len(match) > 1 {
 		epNumStr := ""

--- a/utils.go
+++ b/utils.go
@@ -279,3 +279,11 @@ func timer(name string) func() {
         fmt.Printf("%s took %v\n", name, time.Since(start))
     }
 }
+
+// for logging purposes
+const (
+	INFO = "[INFO] " 					// no color
+	WARN = "\033[93m[WARN]\033[0m "		// yellow
+	ERROR = "\033[91m[ERROR]\033[0m "	// red
+	FATAL = "\033[91m[FATAL]\033[0m "	// red
+)

--- a/utils.go
+++ b/utils.go
@@ -283,9 +283,15 @@ func timer(name string) func() {
 
 // for logging purposes
 const (
+	// for informational purposes
 	INFO = "[INFO] " 					// no color
+
+	// can safely skip error, doesn't interrupt process
 	WARN = "\033[93m[WARN]\033[0m "		// yellow
-	ERROR = "\033[91m[ERROR]\033[0m "	// red
+	
+	// cannot safely skip error, must interrupt process
 	FATAL = "\033[91m[FATAL]\033[0m "	// red
+	
+	// for timing purposes
 	TIME = "\033[94m[TIME]\033[0m "		// blue
 )

--- a/utils.go
+++ b/utils.go
@@ -16,7 +16,8 @@ import (
 
 // checks if a file is a media file through checking the file extension
 //
-// current media extensions: .mkv, .mp4, .avi, .mov, .webm, .ts
+// current media extensions:
+//	`.mkv`, `.mp4`, `.avi`, `.mov`, `.webm`, `.ts`
 func IsMediaFile(file string) bool {
 	// TODO: find a better way to identify media files
 	mediaExtensions := map[string]bool{
@@ -56,7 +57,6 @@ func HasMovie(path string) (bool, error) {
 //
 // usage: sort.Sort(FilenameSort(slice of paths))
 type FilenameSort []string
-
 // implement sort.Interface (Len, Less, Swap)
 
 func (f FilenameSort) Len() int {
@@ -194,10 +194,12 @@ func SplitRegexByPipe(s string) []string {
 // note that this is usually called after SplitRegexByPipe so outermost pipes are removed first
 //
 // examples:
-//	`(a|b)` --> true
-//	`(a(b)a)` --> false
-//	`(a|b|c)` --> true
-//	`a` --> true
+//	`a` 		--> true
+//	`(a)` 		--> true
+//	`(a|b)` 	--> true
+//	`(a(b)a)` 	--> false
+//	`(a\(b\)c)`	--> true
+// 	`(a[(b)]c)`	--> true
 func HasOnlyOneMatchGroup(s string) bool {
 	openingCount := 0
 	closingCount := 0
@@ -253,10 +255,10 @@ func HasOnlyOneMatchGroup(s string) bool {
 
 // returns the nth parent directory
 //
-// examples:
-// 	ParentN("a/b/c", 1) --> "a/b"
-// 	ParentN("a/b/c", 2) --> "a"
-// 	ParentN("a/b/c", 3) --> ""
+//	examples:
+// 	ParentN("path/to/dir", 1) --> "to"
+// 	ParentN("path/to/dir", 2) --> "path"
+// 	ParentN("path/to/dir", 3) --> ""
 func ParentN(path string, n int) string {
 	for i := 0; i < n; i++ {
 		path = filepath.Dir(path)
@@ -299,7 +301,7 @@ func timer(name string) func() {
 
 // for logging purposes
 const (
-	// for informational purposes
+	// for informational logs
 	INFO = "[INFO] " 					// no color
 
 	// can safely skip error, doesn't interrupt process

--- a/utils.go
+++ b/utils.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 	"strings"
 	"unicode"
+	"time"
 )
 
 func IsMediaFile(file string) bool {
@@ -263,4 +264,18 @@ func SafeErrorF(s string, args ...interface{}) SafeError {
 
 func (s SafeError) Error() string {
 	return s.safe.Error()
+}
+
+// Usage: put `defer timer("func_name")()` at the start of a function
+//
+// where "func_name" is just for logging purposes
+//
+// Reference:
+//   - https://stackoverflow.com/questions/45766572/is-there-an-efficient-way-to-calculate-execution-time-in-golang
+// thank you Cerise Limón
+func timer(name string) func() {
+    start := time.Now()
+    return func() {
+        fmt.Printf("%s took %v\n", name, time.Since(start))
+    }
 }


### PR DESCRIPTION
closes #17, closes #35, closes #38
*wow this is a big pr and I shouldve separated this into multiple small ones but oh whale*

### new
1. `SafeError` type to have type assertion on returned errors if user inputted `--help, -h` or `--version, -v`
    - this is used on parsing arguments when encountering `-h` or `-v` switches which will safely exit the **gorn** after printing to console the requested information
2. using `log` instead of `fmt`
    - logs have their own headers: `[INFO]`, `[WARN]`, `[FATAL]`, and `[TIME]`
    - the headers are colored by ansi color escape sequences
3. renaming is now **concurrent**
    - preparing to rename + renaming series is in its own goroutine, separate from the movie counterpart which also has its own
    - **in preparing to rename and renaming:**
        - each entry is in their own goroutine, getting rename prereqs and renaming the files
        - since entries don't block one another, each [series types](https://github.com/saltkid/gorn/wiki/Directory-Structure#series-types) / [movie types](https://github.com/saltkid/gorn/wiki/Directory-Structure#movie-types) don't wait for the previous one to finish to start and can just put entries under them into a goroutine
        - for more info, see issue #17 
4. use of `timer()` to time functions
    - [credits](https://stackoverflow.com/questions/45766572/is-there-an-efficient-way-to-calculate-execution-time-in-golang), thank you Cerise Limón

### changes
1. Errors are now only possible in the tokenizing and parsing of args passed to **gorn**
    - The rest of the process which is preparing for renaming and renaming, instead of returning error if encountering one, will safely skip renaming the file / files under a dir, and print a warning log to the console
    - removed a lot of errors that are redundant (aka what tokenizing and parsing of args already checked)
2. use constants instead of string comparisons which are typo prone
3. rename `AdditionalOptions` to `Flags` to reflect the changes in cli restructuring in #33 

### plus some others: some small bugfixes
1. fix regex splitting by outermost pipe by considering escaping pipes or enclosing them in brackets `[]`
2. fix regex checking if there's only one match group by considering non capturing match groups `(?:...)` and escaping parenthesis
3. add season 0 if it only matches the pattern
4. update `README.md` and wiki to accommodate changes