### PR TITLE
Feat/rework cli args 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ These are additional options that can be passed to the cli. For a more detailed 
 1. `--keep-ep-num | -ken`
     - **values:** `var` or none
 2. `--starting-ep-num | -sen`
-    - **values:** `var` or none
+    - **values:** `<int> | var`
 3. `--has-season-0 | -s0`
     - **values:** `var` or none
 4. `--options | -o`

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Switches are flags that switch the behavior of **gorn** from its default behavio
 These are additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
 
 1. `--keep-ep-num | -ken`
-    - **values:** `yes | no | default | var`
+    - **values:** `var` or none
 2. `--starting-ep-num | -sen`
-    - **values:** `<num> | default | var`
+    - **values:** `var` or none
 3. `--has-season-0 | -s0`
-    - **values:** `yes | no | default | var`
+    - **values:** `var` or none
 4. `--options | -o`
     - **values:** none
 5.  `--logs | -l`
-    - **values:** `all | none | <log-header>`
+    - **values:** `<log-header>` or none
 6. `--naming-scheme | -ns`
     - **values:** `"<scheme>"| default | var`
 

--- a/README.md
+++ b/README.md
@@ -84,17 +84,17 @@ Switches are flags that switch the behavior of **gorn** from its default behavio
 These are additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
 
 1. `--keep-ep-num | -ken`
-    - **values:** `var` or no input
+    - **values:** `var` or no value
 2. `--starting-ep-num | -sen`
-    - **values:** `<int> | var`
+    - **values:** `<int>`, `var`
 3. `--has-season-0 | -s0`
-    - **values:** `var` or no input
+    - **values:** `var` or no value
 4. `--options | -o`
-    - **values:** no input
+    - **values:** no value
 5.  `--logs | -l`
-    - **values:** `<log-header> | none` or no input
+    - **values:** `<log-header>`, `none` or no value
 6. `--naming-scheme | -ns`
-    - **values:** `"<scheme>"| default | var`
+    - **values:** `"<scheme>"`, `default`, `var`
 
 ### [*scheme*](https://github.com/saltkid/gorn/wiki/Usage#naming-scheme-apis)
 scheme can be composed of any character (as long as its a valid filename) and/or APIs enclosed in <> like:

--- a/README.md
+++ b/README.md
@@ -84,15 +84,15 @@ Switches are flags that switch the behavior of **gorn** from its default behavio
 These are additional options that can be passed to the cli. For a more detailed explanation, see [this wiki page](https://github.com/saltkid/gorn/wiki/Usage#optional-flags)
 
 1. `--keep-ep-num | -ken`
-    - **values:** `var` or none
+    - **values:** `var` or no input
 2. `--starting-ep-num | -sen`
     - **values:** `<int> | var`
 3. `--has-season-0 | -s0`
-    - **values:** `var` or none
+    - **values:** `var` or no input
 4. `--options | -o`
-    - **values:** none
+    - **values:** no input
 5.  `--logs | -l`
-    - **values:** `<log-header>` or none
+    - **values:** `<log-header> | none` or no input
 6. `--naming-scheme | -ns`
     - **values:** `"<scheme>"| default | var`
 

--- a/help.go
+++ b/help.go
@@ -148,61 +148,65 @@ func HelpMovies(verbose bool) {
 func HelpKEN(verbose bool) {
 	fmt.Printf("%-60s%s", "  --keep-ep-num, -ken",
 		"Keep original episode numbers in filename based on common naming patterns\n")
-	fmt.Println("    args: yes | no | default | var")
+	fmt.Println("    args: var | no input")
 	if verbose {
+		fmt.Println("\n  examples: gorn -ken root /path/to/root")
+		fmt.Println(`            gorn --keep-ep-nums var root /path/to/root"`)
 		fmt.Println("\n  common naming patterns taken into account are:")
 		fmt.Println("    S01E02     | S03.E04   | S05_E06 | S07-E08 | S09xE10 | S11 E12")
 		fmt.Println("    01.02      | 03_04     | 05-06   | 07 x 08 | 09 10   | [11x12]")
 		fmt.Println("    Episode 01 | Episode02 | EP03    | EP-04   | E_05    | EP.06")
-		fmt.Println("\n  '.', '-', 'x', '_', and ' ' are valid season-episode separators.")
-		fmt.Println("  NOTE: This is not how the default naming scheme looks like in gorn. These common naming cases are just here to read the episode number from the filename.")
+		fmt.Println("\n  NOTES:")
+		fmt.Println("        If -ken is omitted, the default value is 'false'")
+		fmt.Println("        If no input follows -ken, the default value is 'true'")
+		fmt.Println("\n        '.', '-', 'x', '_', and ' ' are valid season-episode separators.")
 		fmt.Println("        second number is episode")
+		fmt.Println("        This is not how the default naming scheme looks like in gorn.")
+		fmt.Println("        These common naming cases are only used to read the episode number from the filename.")
 		fmt.Println("        if no common naming pattern is found, the file will not be renamed.")
-		fmt.Println("\n  examples: gorn -ken yes root /path/to/root")
-		fmt.Println("            gorn -ken no root /path/to/root")
-		fmt.Println("            gorn -ken default root /path/to/root")
-		fmt.Println("            gorn -ken var root /path/to/root")
 	}
 }
 
 func HelpSEN(verbose bool) {
 	fmt.Printf("%-60s%s", "  --starting-ep-num, -sen",
 		"Set the starting episode number in renaming.\n")
-	fmt.Println("    args: <int> | default | var")
+	fmt.Println("    args: <int> | var | no input")
 	if verbose {
+		fmt.Println("\n  examples: gorn -sen 1 root /path/to/root")
+		fmt.Println("            gorn -sen var root /path/to/root")
+		fmt.Println("            gorn --starting-ep-num 25 root /path/to/root")
 		fmt.Println("\n  This can be useful if episodes are in absolute order but in different season directories for separation")
 		fmt.Println("  User can specify different starting episode number for each of those seasons")
-		fmt.Println("\n  examples: gorn -sen 1 root /path/to/root")
-		fmt.Println("            gorn -sen 25 root /path/to/root")
-		fmt.Println("            gorn -sen default root /path/to/root")
-		fmt.Println("            gorn -sen var root /path/to/root")
+		fmt.Println("\n  NOTES: If -sen is omitted or no input follows -sen, the default value is '1'")
 	}
 }
 
 func HelpS0(verbose bool) {
 	fmt.Printf("%-60s%s", "  --has-season-0, -s0",
 		"Treat extras/specials/OVA/etc directory as season 0\n")
-	fmt.Println("    args: yes | no | default | var")
+	fmt.Println("    args: var | no input")
 	if verbose {
+		fmt.Println("\n  examples: gorn -s0 root /path/to/root")
+		fmt.Println(`            gorn --has-season-0 var root /path/to/root"`)
 		fmt.Println("\n  Note that if this is set, there must be only one specials/extras/OVA directory under a series entry")
 		fmt.Println("\n  This is more useful if specified at the series entry level by doing")
 		fmt.Println("  'gorn -r path/to/root -s0 var'")
 		fmt.Println("  This will let gorn prompt the user at: per series type level and per series entry level")
 		fmt.Println("  if var is inputted at the per series type level, it will prompt the user at per series entry level which is where this flag will be most useful")
-		fmt.Println("\n  examples: gorn -s0 yes root /path/to/root")
-		fmt.Println("            gorn -s0 no root /path/to/root")
-		fmt.Println("            gorn -s0 default root /path/to/root")
-		fmt.Println("            gorn -s0 var root /path/to/root")
+		fmt.Println("\n  NOTES:")
+		fmt.Println("        If -s0 is omitted, the default value is 'false'")
+		fmt.Println("        If no input follows -s0, the default value is 'true'")
+
 	}
 }
 
 func HelpNS(verbose bool) {
 	fmt.Printf("%-60s%s", "  --naming-scheme, -ns",
 		"Change the naming scheme\n")
-	fmt.Println("    args: <scheme> | default | var")
+	fmt.Println(`    args: "<scheme>" | default | var`)
 	if verbose {
 		fmt.Println("\n  examples: gorn -ns default root /path/to/root")
-		fmt.Println(`            gorn -ns "S<season_num>E<episode_num> <parent: 1,5> <parent-parent: '_(\d+)_'> <p-3: 2,5> [<self: '\.(\w+)$'>] root /path/to/root"`)
+		fmt.Println(`            gorn --naming-scheme "S<season_num>E<episode_num> <parent: 1,5> <parent-parent: '_(\d+)_'> <p-3: 2,5> [<self: '\.(\w+)$'>] root /path/to/root"`)
 		fmt.Println("\n  Naming Scheme APIs:")
 		fmt.Println("    1. <season_num>")
 		fmt.Println("       represents the season number which is based on series type, and directory structure and naming")
@@ -235,17 +239,19 @@ func HelpNS(verbose bool) {
 		fmt.Println("\n    4. <self>")
 		fmt.Println("       same as parent but instead of being based on the parent directory name, it is based on the name of the media file before renaming it")
 		fmt.Println("       additional options are the same as well except for `<p-number>`. self has no short form")
+		fmt.Println("\n  NOTES:")
+		fmt.Println("    -ns must be followed by a value")
 	}
 }
 
 func HelpLogs(verbose bool) {
 	fmt.Printf("%-60s%s", "  --log, -l",
 		"Prints the logs to the console\n")
-	fmt.Println("    args: all | none | <header>")
+	fmt.Println("    args: <log-header> | no input")
 	if verbose {
-		fmt.Println("\n  examples: gorn -l")
-		fmt.Println("            gorn -l all")
-		fmt.Println("            gorn -l info")
+		fmt.Println("\n  examples: gorn -l root /path/to/root")
+		fmt.Println("            gorn -l info root /path/to/root")
+		fmt.Println("            gorn --logs time-only")
 		fmt.Println("\n  Headers:")
 		fmt.Println("    info: informational logs")
 		fmt.Println("        : shows info, warn, and fatal logs")
@@ -255,25 +261,24 @@ func HelpLogs(verbose bool) {
 		fmt.Println("        : shows only fatal logs")
 		fmt.Println("    time: logs for timing processes; for performance purposes")
 		fmt.Println("        : shows time, info, warn, and fatal logs")
-		fmt.Println("\n  Notes:")
-		fmt.Println("    - if no args are specified, all logs will be shown")
-		fmt.Println("    - only one --logs arg can be specified")
+		fmt.Println("\n  NOTE: if --logs is omitted no input follows --logs, the default value of 'info' will be the value")
 	}
 }
 
 func HelpOptions(verbose bool) {
 	fmt.Printf("%-60s%s", "  --options, -o",
 		"Assign none to Flags that the user did not explicitly assign anything to in the initial execution of gorn\n")
-	fmt.Println("    args: all | none | <header>")
 	if verbose {
+		fmt.Println("\n  example: gorn -o root /path/to/root")
+		fmt.Println("           gorn --options root /path/to/root")
 		fmt.Println("\n  By default, without --options, if the user did not explicitly assign")
 		fmt.Println("  anything to the flags, gorn will assign default values to the flags.")
 		fmt.Println("  This behavior can be overridden by using --options")
 		fmt.Println("\n  example: gorn --options --keep-ep-nums")
 		fmt.Println("\n  In the example above, --keep-ep-nums will have the default value of true")
-		fmt.Println("  However, --starting-ep-num and --has-season-0 is not explicitly assigned")
-		fmt.Println("  to the flags. So, gorn will assign the default value of false to the flags")
-		fmt.Println("  This means the user will be prompted to assign a value to the above two flags at:")
+		fmt.Println("  However, --starting-ep-num, --has-season-0, and --naming-scheme is not explicitly")
+		fmt.Println("  passed by the user. So, gorn will assign none to the flags")
+		fmt.Println("\n  This means the user will be prompted to assign a value to the above two flags at:")
 		fmt.Println("    1. per series type level")
 		fmt.Println("    2. per series entry level")
 		fmt.Println("    3. per season of series entry level")

--- a/help.go
+++ b/help.go
@@ -170,14 +170,16 @@ func HelpKEN(verbose bool) {
 func HelpSEN(verbose bool) {
 	fmt.Printf("%-60s%s", "  --starting-ep-num, -sen",
 		"Set the starting episode number in renaming.\n")
-	fmt.Println("    args: <int> | var | no input")
+	fmt.Println("    args: <int> | var")
 	if verbose {
 		fmt.Println("\n  examples: gorn -sen 1 root /path/to/root")
 		fmt.Println("            gorn -sen var root /path/to/root")
 		fmt.Println("            gorn --starting-ep-num 25 root /path/to/root")
 		fmt.Println("\n  This can be useful if episodes are in absolute order but in different season directories for separation")
 		fmt.Println("  User can specify different starting episode number for each of those seasons")
-		fmt.Println("\n  NOTES: If -sen is omitted or no input follows -sen, the default value is '1'")
+		fmt.Println("\n  NOTES:")
+		fmt.Println("        If -sen is omitted, the default value is '1'")
+		fmt.Println("        -sen must be followed by a value")
 	}
 }
 

--- a/help.go
+++ b/help.go
@@ -148,7 +148,7 @@ func HelpMovies(verbose bool) {
 func HelpKEN(verbose bool) {
 	fmt.Printf("%-60s%s", "  --keep-ep-num, -ken",
 		"Keep original episode numbers in filename based on common naming patterns\n")
-	fmt.Println("    args: var | no input")
+	fmt.Println("    args: var | no value")
 	if verbose {
 		fmt.Println("\n  examples: gorn -ken root /path/to/root")
 		fmt.Println(`            gorn --keep-ep-nums var root /path/to/root"`)
@@ -158,7 +158,7 @@ func HelpKEN(verbose bool) {
 		fmt.Println("    Episode 01 | Episode02 | EP03    | EP-04   | E_05    | EP.06")
 		fmt.Println("\n  NOTES:")
 		fmt.Println("        If -ken is omitted, the default value is 'false'")
-		fmt.Println("        If no input follows -ken, the default value is 'true'")
+		fmt.Println("        If no value follows -ken, the default value is 'true'")
 		fmt.Println("\n        '.', '-', 'x', '_', and ' ' are valid season-episode separators.")
 		fmt.Println("        second number is episode")
 		fmt.Println("        This is not how the default naming scheme looks like in gorn.")
@@ -186,7 +186,7 @@ func HelpSEN(verbose bool) {
 func HelpS0(verbose bool) {
 	fmt.Printf("%-60s%s", "  --has-season-0, -s0",
 		"Treat extras/specials/OVA/etc directory as season 0\n")
-	fmt.Println("    args: var | no input")
+	fmt.Println("    args: var | no value")
 	if verbose {
 		fmt.Println("\n  examples: gorn -s0 root /path/to/root")
 		fmt.Println(`            gorn --has-season-0 var root /path/to/root"`)
@@ -197,7 +197,7 @@ func HelpS0(verbose bool) {
 		fmt.Println("  if var is inputted at the per series type level, it will prompt the user at per series entry level which is where this flag will be most useful")
 		fmt.Println("\n  NOTES:")
 		fmt.Println("        If -s0 is omitted, the default value is 'false'")
-		fmt.Println("        If no input follows -s0, the default value is 'true'")
+		fmt.Println("        If no value follows -s0, the default value is 'true'")
 
 	}
 }
@@ -249,7 +249,7 @@ func HelpNS(verbose bool) {
 func HelpLogs(verbose bool) {
 	fmt.Printf("%-60s%s", "  --log, -l",
 		"Prints the logs to the console\n")
-	fmt.Println("    args: <log-header> | none | no input")
+	fmt.Println("    args: <log-header> | none | no value")
 	if verbose {
 		fmt.Println("\n  examples: gorn -l root /path/to/root")
 		fmt.Println("            gorn -l info root /path/to/root")
@@ -263,7 +263,7 @@ func HelpLogs(verbose bool) {
 		fmt.Println("        : shows only fatal logs")
 		fmt.Println("    time: logs for timing processes; for performance purposes")
 		fmt.Println("        : shows time, info, warn, and fatal logs")
-		fmt.Println("\n  NOTE: if --logs is omitted no input follows --logs, the default value of 'info' will be the value")
+		fmt.Println("\n  NOTE: if --logs is omitted or no value follows --logs, the default value of 'info' will be the value")
 	}
 }
 

--- a/help.go
+++ b/help.go
@@ -249,7 +249,7 @@ func HelpNS(verbose bool) {
 func HelpLogs(verbose bool) {
 	fmt.Printf("%-60s%s", "  --log, -l",
 		"Prints the logs to the console\n")
-	fmt.Println("    args: <log-header> | no input")
+	fmt.Println("    args: <log-header> | none | no input")
 	if verbose {
 		fmt.Println("\n  examples: gorn -l root /path/to/root")
 		fmt.Println("            gorn -l info root /path/to/root")

--- a/help.go
+++ b/help.go
@@ -4,14 +4,14 @@ import (
 	"fmt"
 )
 
-func WelcomeMsg(version string) {
-	Version(version)
+func WelcomeMsg() {
+	Version()
 	fmt.Println("renames series/movies media files based on directory naming and structure")
 	fmt.Println("for more usage information, run 'gorn -h'")
 	fmt.Println("https://github.com/saltkid/gorn")
 }
 
-func Version(version string) {
+func Version() {
 	fmt.Println("gorn - go rename tool")
 	fmt.Println("version:", version)
 }

--- a/main.go
+++ b/main.go
@@ -40,17 +40,20 @@ func main() {
 	//   - we already checked for errors in ParseArgs and TokenizeArgs
 	//   - we can safely skip renaming a file if an error does occur
 	seriesEntries, movieEntries := FetchEntries(args.root, args.series, args.movies)
+	if len(seriesEntries) == 0 && args.flags.AnyAssigned() {
+		gornLog(WARN, "Flags were set, but no series entries were found. Flags modify the behavior of renaming series entries only.")
+	}
 	LogRawEntries(seriesEntries, movieEntries)
 
 	wg := new(sync.WaitGroup)
 
 	series := &Series{}
 	wg.Add(1)
-	go ProcessMedia(series, seriesEntries, args.options, wg)
+	go ProcessMedia(series, seriesEntries, args.flags, wg)
 
 	movies := &Movies{}
 	wg.Add(1)
-	go ProcessMedia(movies, movieEntries, args.options, wg)
+	go ProcessMedia(movies, movieEntries, args.flags, wg)
 
 	wg.Wait()
 	movies.LogEntries()

--- a/main.go
+++ b/main.go
@@ -10,6 +10,13 @@ import (
 
 var version string
 var logLevel LogLevel = INFO_LEVEL // default log level
+type Mode uint8
+const (
+	_ Mode = iota
+	NORMAL
+	HELP
+	VERSION
+)
 
 func main() {
 	defer timer("main")()
@@ -17,7 +24,7 @@ func main() {
 	// handling input of user
 	// errors can happen here and interrupt the process
 	if len(os.Args) < 2 {
-		WelcomeMsg(version)
+		WelcomeMsg()
 		return
 	}
 	rawArgs, err := TokenizeArgs(os.Args[1:])
@@ -25,39 +32,44 @@ func main() {
 		gornLog(FATAL, err)
 	}
 
-	args, err := ParseArgs(rawArgs)
+	args, mode, err := ParseArgs(rawArgs)
 	if err != nil {
-		// scuffed safe exit for --help and --version
-		if _, ok := err.(SafeError); !ok {
-			gornLog(FATAL, err)
+		gornLog(FATAL, err)
+	}
+	
+	if mode == NORMAL {
+		// renaming process
+		// there should be no errors in renaming process since:
+		//   - we already checked for errors in ParseArgs and TokenizeArgs
+		//   - we can safely skip renaming a file if an error does occur
+		args.Log()
+
+		seriesEntries, movieEntries := FetchEntries(args.root, args.series, args.movies)
+		if len(seriesEntries) == 0 && args.flags.AnyAssigned() {
+			gornLog(WARN, "Flags were set, but no series entries were found. Flags modify the behavior of renaming series entries only. These won't affect movie entries.")
 		}
-		return
+		LogRawEntries(seriesEntries, movieEntries)
+
+		wg := new(sync.WaitGroup)
+
+		series := &Series{}
+		wg.Add(1)
+		go ProcessMedia(series, seriesEntries, args.flags, wg)
+
+		movies := &Movies{}
+		wg.Add(1)
+		go ProcessMedia(movies, movieEntries, args.flags, wg)
+
+		wg.Wait()
+		movies.LogEntries()
+		series.LogEntries()
+
+	} else if mode == HELP {
+		Help(args.switchVal)
+	
+	} else if mode == VERSION {
+		Version()
 	}
-	args.Log()
-
-	// renaming process
-	// there should be no errors in renaming process since:
-	//   - we already checked for errors in ParseArgs and TokenizeArgs
-	//   - we can safely skip renaming a file if an error does occur
-	seriesEntries, movieEntries := FetchEntries(args.root, args.series, args.movies)
-	if len(seriesEntries) == 0 && args.flags.AnyAssigned() {
-		gornLog(WARN, "Flags were set, but no series entries were found. Flags modify the behavior of renaming series entries only.")
-	}
-	LogRawEntries(seriesEntries, movieEntries)
-
-	wg := new(sync.WaitGroup)
-
-	series := &Series{}
-	wg.Add(1)
-	go ProcessMedia(series, seriesEntries, args.flags, wg)
-
-	movies := &Movies{}
-	wg.Add(1)
-	go ProcessMedia(movies, movieEntries, args.flags, wg)
-
-	wg.Wait()
-	movies.LogEntries()
-	series.LogEntries()
 }
 
 // ProcessMedia first categorizes the entries by type, then renames them using the given flags.

--- a/main_test.go
+++ b/main_test.go
@@ -88,7 +88,6 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-
 		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'series is a subdir of root: root test_files series test_files/series'")
@@ -216,7 +215,126 @@ func Test_ParseArgs(t *testing.T) {
 			t.Log(cmd, "\n\t", err)
 		}
 	}
-	t.Log("------------expects success------------")
+	cmd = "root ./test_files -s0 yes"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'yes' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -s0 no"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'no' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -s0 default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'default' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -ken yes"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'yes' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -ken no"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'no' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -ken default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'default' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -sen yes"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'yes' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -sen no"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'no' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
+	cmd = "root ./test_files -sen default"
+	command = strings.Split(cmd, " ")
+	rawArgs, err = TokenizeArgs(command)
+	if err != nil {
+		t.Errorf("unexpected error: '%s'", err)
+	} else {
+		_, _, err = ParseArgs(rawArgs)
+		if err == nil {
+			t.Errorf("expected error 'default' is not a valid arg")
+		} else {
+			t.Log(cmd, "\n\t", err)
+		}
+	}
 	cmd = "root ./test_files -l all"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -224,12 +342,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 		_, _, err := ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
+		if err == nil {
+			t.Errorf("expected error 'invalid value for -l: all'")
 		} else {
-			t.Log(cmd, "\n\t")
+			t.Log(cmd, "\n\t", err)
 		}
 	}
+	t.Log("------------expects success------------")
 	cmd = "root ./test_files -l none"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -269,64 +388,18 @@ func Test_ParseArgs(t *testing.T) {
 			t.Log(cmd, "\n\t")
 		}
 	}
-	cmd = "root ./test_files -s0 yes"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-	}
-	cmd = "root ./test_files -s0 no"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "root ./test_files -s0 default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
 	cmd = "root ./test_files -s0 var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-
 		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
 			t.Log(cmd)
 		}
-
 	}
 	cmd = `root ./test_files -ns "test<season_num>"`
 	command = strings.Split(cmd, " ")
@@ -373,59 +446,12 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-
 		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
 			t.Log(cmd)
 		}
-
-	}
-	cmd = "root ./test_files -ken yes"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "root ./test_files -ken no"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "root ./test_files -ken default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
 	}
 	cmd = "root ./test_files -ken var"
 	command = strings.Split(cmd, " ")
@@ -472,21 +498,6 @@ func Test_ParseArgs(t *testing.T) {
 		}
 
 	}
-	cmd = "root ./test_files -sen default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
 	cmd = "root ./test_files -sen var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -499,29 +510,6 @@ func Test_ParseArgs(t *testing.T) {
 			t.Errorf("unexpected error: %s", err)
 		} else {
 			t.Log(cmd)
-		}
-
-	}
-	cmd = `root ./test_files -ken -sen -s0 -ns "test"`
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		args, _, err := ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			if args.flags.namingScheme.IsNone() {
-				t.Errorf("unexpected error: %s", err)
-			} else {
-				val, _ := args.flags.namingScheme.Get()
-				if val != "test" {
-					t.Errorf("unexpected error: '%s' != test", val)
-				}
-				t.Log(cmd)
-			}
 		}
 
 	}
@@ -684,51 +672,6 @@ func Test_ParseArgs(t *testing.T) {
 		}
 
 	}
-	cmd = "series ./test_files/series -s0 yes"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "series ./test_files/series -s0 no"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "series ./test_files/series -s0 default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
 	cmd = "series ./test_files/series -s0 var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -798,51 +741,6 @@ func Test_ParseArgs(t *testing.T) {
 		}
 
 	}
-	cmd = "series ./test_files/series -ken yes"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "series ./test_files/series -ken no"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "series ./test_files/series -ken default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
 	cmd = "series ./test_files/series -ken var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -888,21 +786,6 @@ func Test_ParseArgs(t *testing.T) {
 		}
 
 	}
-	cmd = "series ./test_files/series -sen default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
 	cmd = "series ./test_files/series -sen var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -915,29 +798,6 @@ func Test_ParseArgs(t *testing.T) {
 			t.Errorf("unexpected error: %s", err)
 		} else {
 			t.Log(cmd)
-		}
-
-	}
-	cmd = `series ./test_files/series -ken -sen -s0 -ns "test"`
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		args, _, err := ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			if args.flags.namingScheme.IsNone() {
-				t.Errorf("unexpected error: %s", err)
-			} else {
-				val, _ := args.flags.namingScheme.Get()
-				if val != "test" {
-					t.Errorf("unexpected error: %s", err)
-				}
-				t.Log(cmd)
-			}
 		}
 
 	}
@@ -957,51 +817,6 @@ func Test_ParseArgs(t *testing.T) {
 			} else {
 				t.Log(cmd)
 			}
-		}
-
-	}
-	cmd = "movies ./test_files/movies -s0 yes"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "movies ./test_files/movies -s0 no"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
-	cmd = "movies ./test_files/movies -s0 default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
 		}
 
 	}
@@ -1073,45 +888,6 @@ func Test_ParseArgs(t *testing.T) {
 		}
 
 	}
-	cmd = "movies ./test_files/movies -ken yes"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-	}
-	cmd = "movies ./test_files/movies -ken no"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-	}
-	cmd = "movies ./test_files/movies -ken default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-	}
 	cmd = "movies ./test_files/movies -ken var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -1151,20 +927,6 @@ func Test_ParseArgs(t *testing.T) {
 			t.Log(cmd)
 		}
 	}
-	cmd = "movies ./test_files/movies -sen default"
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-		_, _, err = ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			t.Log(cmd)
-		}
-
-	}
 	cmd = "movies ./test_files/movies -sen var"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)
@@ -1180,28 +942,6 @@ func Test_ParseArgs(t *testing.T) {
 		}
 
 	}
-	cmd = `movies ./test_files/movies -ken -sen -s0 -ns "test"`
-	command = strings.Split(cmd, " ")
-	rawArgs, err = TokenizeArgs(command)
-	if err != nil {
-		t.Errorf("unexpected error: '%s'", err)
-	} else {
-		args, _, err := ParseArgs(rawArgs)
-		if err != nil {
-			t.Errorf("unexpected error: %s", err)
-		} else {
-			if args.flags.namingScheme.IsNone() {
-				t.Errorf("unexpected error: %s", err)
-			} else {
-				val, _ := args.flags.namingScheme.Get()
-				if val != "test" {
-					t.Errorf("unexpected error: %s", err)
-				}
-				t.Log(cmd)
-			}
-		}
-	}
-
 	cmd = "movies ./test_files/movies -o"
 	command = strings.Split(cmd, " ")
 	rawArgs, err = TokenizeArgs(command)

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'missing root dir'; got -s0 -s0")
 		} else {
@@ -29,7 +29,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'missing series dir'; got -s0")
 		} else {
@@ -44,7 +44,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'missing movies dir'; got -s0")
 		} else {
@@ -59,7 +59,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'missing dir'")
 		} else {
@@ -74,7 +74,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'same dir: root test_files series test_files'")
 		} else {
@@ -89,7 +89,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'series is a subdir of root: root test_files series test_files/series'")
 		} else {
@@ -104,7 +104,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'root is a subdir of series: series test_files root test_files/series'")
 		} else {
@@ -119,7 +119,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'same dir: root test_files movies test_files'")
 		} else {
@@ -134,7 +134,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'movies is a subdir of root: root test_files movies test_files/movies'")
 		} else {
@@ -149,7 +149,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'root is a subdir of movies: movies test_files root test_files/movies'")
 		} else {
@@ -164,7 +164,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'invalid value for -ken: ye'")
 		} else {
@@ -179,7 +179,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'invalid value for -sen: ye'")
 		} else {
@@ -194,7 +194,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'invalid value for -s0: ye'")
 		} else {
@@ -209,7 +209,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err == nil {
 			t.Errorf("expected error 'invalid value for -ns: ye, not enclosed in double quotes'\n%v", args)
 		} else {
@@ -223,11 +223,11 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		pa, err := ParseArgs(rawArgs)
+		_, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd, "\n\t", pa.log)
+			t.Log(cmd, "\n\t")
 		}
 	}
 	cmd = "root ./test_files -l none"
@@ -236,11 +236,11 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		pa, err := ParseArgs(rawArgs)
+		_, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd, "\n\t", pa.log)
+			t.Log(cmd, "\n\t")
 		}
 	}
 	cmd = "root ./test_files -l"
@@ -249,11 +249,11 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		pa, err := ParseArgs(rawArgs)
+		_, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd, "\n\t", pa.log)
+			t.Log(cmd, "\n\t")
 		}
 	}
 	cmd = "root ./test_files -l info"
@@ -262,11 +262,11 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		pa, err := ParseArgs(rawArgs)
+		_, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			t.Log(cmd, "\n\t", pa.log)
+			t.Log(cmd, "\n\t")
 		}
 	}
 	cmd = "root ./test_files -s0 yes"
@@ -276,7 +276,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -290,7 +290,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -305,7 +305,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -320,7 +320,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -335,14 +335,14 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.namingScheme.IsNone() {
+			if args.flags.namingScheme.IsNone() {
 				t.Errorf("unexpected error: 'naming scheme not set'")
 			} else {
-				val, _ := args.options.namingScheme.Get()
+				val, _ := args.flags.namingScheme.Get()
 				if val != "test<season_num>" {
 					t.Errorf("unexpected error: '%s != test<season_num>'", val)
 				} else {
@@ -359,7 +359,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -374,7 +374,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -389,7 +389,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -404,7 +404,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -419,7 +419,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -434,7 +434,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -449,7 +449,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -464,7 +464,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -479,7 +479,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -494,7 +494,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -509,14 +509,14 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.namingScheme.IsNone() {
+			if args.flags.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
 			} else {
-				val, _ := args.options.namingScheme.Get()
+				val, _ := args.flags.namingScheme.Get()
 				if val != "test" {
 					t.Errorf("unexpected error: '%s' != test", val)
 				}
@@ -532,11 +532,11 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			if args.flags.keepEpNums.IsSome() || args.flags.hasSeason0.IsSome() || args.flags.startingEpNum.IsSome() || args.flags.namingScheme.IsSome() {
 				t.Errorf("none of the options should have been set")
 			} else {
 				t.Log(cmd)
@@ -551,10 +551,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 
@@ -565,10 +568,13 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != VERSION {
+				t.Errorf("expected VERSION (3); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 	}
@@ -578,10 +584,13 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 	}
@@ -592,10 +601,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 
@@ -607,10 +619,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 
@@ -622,10 +637,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 
@@ -637,10 +655,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 
@@ -652,10 +673,13 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
-		if err == nil {
-			t.Errorf("supposed to exit safely")
+		_, mode, err := ParseArgs(rawArgs)
+		if err != nil {
+			t.Errorf("unexpected error: %s", err)
 		} else {
+			if mode != HELP {
+				t.Errorf("expected HELP (2); got: %d", mode)
+			}
 			t.Log(cmd, err)
 		}
 
@@ -667,7 +691,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -682,7 +706,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -697,7 +721,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -712,7 +736,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -727,14 +751,14 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.namingScheme.IsNone() {
+			if args.flags.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
 			} else {
-				val, _ := args.options.namingScheme.Get()
+				val, _ := args.flags.namingScheme.Get()
 				if val != "test<episode_num>" {
 					t.Errorf("unexpected error: '%s != test<episode_num>'", val)
 				} else {
@@ -751,7 +775,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -766,7 +790,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -781,7 +805,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -796,7 +820,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -811,7 +835,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -826,7 +850,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -841,7 +865,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -856,7 +880,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -871,7 +895,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -886,7 +910,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -901,14 +925,14 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.namingScheme.IsNone() {
+			if args.flags.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
 			} else {
-				val, _ := args.options.namingScheme.Get()
+				val, _ := args.flags.namingScheme.Get()
 				if val != "test" {
 					t.Errorf("unexpected error: %s", err)
 				}
@@ -924,11 +948,11 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			if args.flags.keepEpNums.IsSome() || args.flags.hasSeason0.IsSome() || args.flags.startingEpNum.IsSome() || args.flags.namingScheme.IsSome() {
 				t.Errorf("none of the options should be present")
 			} else {
 				t.Log(cmd)
@@ -943,7 +967,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -958,7 +982,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -973,7 +997,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -988,7 +1012,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1003,14 +1027,14 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.namingScheme.IsNone() {
+			if args.flags.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
 			} else {
-				val, _ := args.options.namingScheme.Get()
+				val, _ := args.flags.namingScheme.Get()
 				if val != "test" {
 					t.Errorf("unexpected error: %s", err)
 				}
@@ -1026,7 +1050,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1041,7 +1065,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1055,7 +1079,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1068,7 +1092,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1081,7 +1105,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1094,7 +1118,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1107,7 +1131,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1120,7 +1144,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1133,7 +1157,7 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1148,7 +1172,7 @@ func Test_ParseArgs(t *testing.T) {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
 
-		_, err = ParseArgs(rawArgs)
+		_, _, err = ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
@@ -1162,14 +1186,14 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.namingScheme.IsNone() {
+			if args.flags.namingScheme.IsNone() {
 				t.Errorf("unexpected error: %s", err)
 			} else {
-				val, _ := args.options.namingScheme.Get()
+				val, _ := args.flags.namingScheme.Get()
 				if val != "test" {
 					t.Errorf("unexpected error: %s", err)
 				}
@@ -1184,17 +1208,17 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.keepEpNums.IsSome() || args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			if args.flags.keepEpNums.IsSome() || args.flags.hasSeason0.IsSome() || args.flags.startingEpNum.IsSome() || args.flags.namingScheme.IsSome() {
 				t.Errorf(`unexpected error: keep ep nums, has season 0, starting episode num, or naming scheme should not be set when: only -o is present
 				keep ep nums: %s
 				has season 0: %s
 				starting episode num: %s
 				naming scheme: %s
-				args: %s`, args.options.keepEpNums, args.options.hasSeason0, args.options.startingEpNum, args.options.namingScheme, rawArgs)
+				args: %s`, args.flags.keepEpNums, args.flags.hasSeason0, args.flags.startingEpNum, args.flags.namingScheme, rawArgs)
 			} else {
 				t.Log(cmd)
 			}
@@ -1207,16 +1231,16 @@ func Test_ParseArgs(t *testing.T) {
 	if err != nil {
 		t.Errorf("unexpected error: '%s'", err)
 	} else {
-		args, err := ParseArgs(rawArgs)
+		args, _, err := ParseArgs(rawArgs)
 		if err != nil {
 			t.Errorf("unexpected error: %s", err)
 		} else {
-			if args.options.hasSeason0.IsSome() || args.options.startingEpNum.IsSome() || args.options.namingScheme.IsSome() {
+			if args.flags.hasSeason0.IsSome() || args.flags.startingEpNum.IsSome() || args.flags.namingScheme.IsSome() {
 				t.Errorf("unexpected error: has season 0, starting episode num, or naming scheme should not be set when: only -ken is set and -o is present")
 			} else {
-				if args.options.keepEpNums.IsNone() {
+				if args.flags.keepEpNums.IsNone() {
 					t.Errorf("unexpected error: keep ep nums should be set to yes")
-				} else if val, _ := args.options.keepEpNums.Get(); val != true {
+				} else if val, _ := args.flags.keepEpNums.Get(); val != true {
 					t.Errorf("unexpected error: keep ep nums should be set to yes")
 				} else {
 					t.Log(cmd, "\n\t", args)

--- a/parse_args.go
+++ b/parse_args.go
@@ -312,74 +312,42 @@ func ParseArgs(args []Arg) (Args, Mode, error) {
 			if parsedArgs.flags.hasSeason0.IsSome() && isAssigned["--has-season-0"] {
 				return Args{}, 0, fmt.Errorf("only one --has-season-0 flag is allowed")
 			}
-			// use default value
-			if arg.value == "" {
+			switch arg.value {
+			case "":
 				parsedArgs.flags.hasSeason0 = some[bool](true)
 				isAssigned["--has-season-0"] = true
-
-			} else if arg.value != "yes" && arg.value != "var" && arg.value != "no" && arg.value != "default" {
-				return Args{}, 0, fmt.Errorf("invalid value '%s' for flag --has-season-0. Must be 'yes', 'no', 'var, or 'default", arg.value)
-
-			} else {
-				switch arg.value {
-				case "yes":
-					parsedArgs.flags.hasSeason0 = some[bool](true)
-				case "no", "default":
-					parsedArgs.flags.hasSeason0 = some[bool](false)
-				case "var":
-					parsedArgs.flags.hasSeason0 = none[bool]()
-				}
+			case "var":
+				parsedArgs.flags.hasSeason0 = none[bool]()
 				isAssigned["--has-season-0"] = true
+			default:
+				return Args{}, 0, fmt.Errorf("invalid value '%s' for flag --has-season-0. Must be 'var, or no input", arg.value)
 			}
 
 		} else if arg.name == "--keep-ep-nums" || arg.name == "-ken" {
 			if parsedArgs.flags.keepEpNums.IsSome() && isAssigned["--keep-ep-nums"] {
 				return Args{}, 0, fmt.Errorf("only one --keep-ep-nums flag is allowed")
 			}
-
-			// use default value
-			if arg.value == "" {
+			switch arg.value {
+			case "":
 				parsedArgs.flags.keepEpNums = some[bool](true)
 				isAssigned["--keep-ep-nums"] = true
-
-			} else if arg.value != "yes" && arg.value != "var" && arg.value != "no" && arg.value != "default" {
-				return Args{}, 0, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'yes', 'no', 'var', or 'default", arg.value)
-
-			} else {
-				switch arg.value {
-				case "yes":
-					parsedArgs.flags.keepEpNums = some[bool](true)
-				case "no", "default":
-					parsedArgs.flags.keepEpNums = some[bool](false)
-				case "var":
-					parsedArgs.flags.keepEpNums = none[bool]()
-				}
+			case "var":
+				parsedArgs.flags.keepEpNums = none[bool]()
 				isAssigned["--keep-ep-nums"] = true
+			default:
+				return Args{}, 0, fmt.Errorf("invalid value '%s' for --keep-ep-nums. Must be 'var', or no input", arg.value)
 			}
 
 		} else if arg.name == "--starting-ep-num" || arg.name == "-sen" {
 			if parsedArgs.flags.startingEpNum.IsSome() && isAssigned["--starting-ep-num"] {
 				return Args{}, 0, fmt.Errorf("only one --starting-ep-num flag is allowed")
 			}
-
-			// use default value
-			if arg.value == "" {
-				parsedArgs.flags.startingEpNum = some[int](1)
+			switch arg.value {
+			case "var":
+				parsedArgs.flags.startingEpNum = none[int]()
 				isAssigned["--starting-ep-num"] = true
-
-			} else if value, err := strconv.Atoi(arg.value); err != nil && value < 1 && arg.value != "var" && arg.value != "default" {
-				return Args{}, 0, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be a valid positive int or 'var", arg.value)
-
-			} else {
-				switch arg.value {
-				case "var":
-					parsedArgs.flags.startingEpNum = none[int]()
-				case "default":
-					parsedArgs.flags.startingEpNum = some[int](1)
-				default:
-					parsedArgs.flags.startingEpNum = some[int](value)
-				}
-				isAssigned["--starting-ep-num"] = true
+			default:
+				return Args{}, 0, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be a valid positive int, or 'var'", arg.value)
 			}
 
 		} else if arg.name == "--options" || arg.name == "-o" {

--- a/parse_args.go
+++ b/parse_args.go
@@ -180,7 +180,7 @@ func ToLogLevel(s string) (LogLevel, error) {
 		return TIME_ONLY, nil
 	case "warn":
 		return WARN_LEVEL, nil
-	case "info", "", "all":
+	case "info", "":
 		return INFO_LEVEL, nil
 	case "time":
 		return TIME_LEVEL, nil
@@ -347,7 +347,12 @@ func ParseArgs(args []Arg) (Args, Mode, error) {
 				parsedArgs.flags.startingEpNum = none[int]()
 				isAssigned["--starting-ep-num"] = true
 			default:
-				return Args{}, 0, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be a valid positive int, or 'var'", arg.value)
+				int_val, err := strconv.Atoi(arg.value)
+				if err != nil {
+					return Args{}, 0, fmt.Errorf("invalid value '%s' for --starting-ep-num. Must be a valid positive int, or 'var'", arg.value)	
+				}
+				parsedArgs.flags.startingEpNum = some[int](int_val)
+				isAssigned["--starting-ep-num"] = true
 			}
 
 		} else if arg.name == "--options" || arg.name == "-o" {
@@ -578,8 +583,8 @@ func ValidateRoots(root []string, series []string, movies []string) error {
 			} else if strings.EqualFold(filepath.Dir(dir), dir2) {
 				return fmt.Errorf("directory %s is a subdirectory of directory %s", dir, dir2)
 			
-			} else if strings.EqualFold(dir2, filepath.Dir(dir)) {
-				return fmt.Errorf("directory %s is a subdirectory of directory %s", dir2, dir)
+			} else if strings.EqualFold(dir, filepath.Dir(dir2)) {
+				return fmt.Errorf("directory %s is a subdirectory of directory %s", dir, dir2)
 			}
 		}
 	}

--- a/parse_args.go
+++ b/parse_args.go
@@ -602,10 +602,6 @@ func ValidateRoots(root []string, series []string, movies []string) error {
 	}
 
 	for i, dir := range combinedDirs {
-		// check if exists
-		if _, err := os.Stat(dir); err != nil {
-			return fmt.Errorf("directory %s does not exist", dir)
-		}
 		// check if any directory is duplicated, or is a subdirectory of another directory
 		for _, dir2 := range combinedDirs[i+1:] {
 			if strings.EqualFold(dir, dir2) {

--- a/utils.go
+++ b/utils.go
@@ -3,7 +3,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -266,26 +265,6 @@ func ParentN(path string, n int) string {
 		path = filepath.Dir(path)
 	}
 	return filepath.Base(path)
-}
-
-// specifically for exiting safely when user passed these switches:
-//
-//	`--help, -h`
-//	`--version, -v`
-type SafeError struct {
-	safe error
-}
-
-// acts exactly like fmt.Errorf but returns a SafeError instead of error
-func SafeErrorF(s string, args ...interface{}) SafeError {
-	return SafeError{
-		safe: fmt.Errorf(s, args...),
-	}
-}
-
-// returns the underlying safe error as a string
-func (s SafeError) Error() string {
-	return s.safe.Error()
 }
 
 // Usage: put `defer timer("func_name")()` at the start of a function


### PR DESCRIPTION
### new
1. `Mode` replaces `SafeExit` error
    - `Mode` just dictates which logs to print
### changes
1. remove `yes/no/default` args for flags, except `--naming-scheme` which still has `default`
    - its mostly just `var` and no input now
2. roots and sources validation is simplified from 6 1d and 2 2d for loops into one 2d loop
3. `--starting-ep-num` needs to have a value now and doesn't have a default value if no value follows it
4. updated README and wiki to accommodate changes